### PR TITLE
Install the correct package from pypi

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -36,7 +36,7 @@ commands:
                 sudo $PIP install awscli --upgrade
               else
                 # This installs the AWS CLI to ~/.local/bin. Make sure that ~/.local/bin is in your $PATH.
-                $PIP install aws --upgrade --user
+                $PIP install awscli --upgrade --user
               fi
             elif [[ $(which unzip curl | wc -l) -eq 2 ]]; then
               cd


### PR DESCRIPTION
If `sudo` is not installed this orb installs the incorrect package off of PyPI, `aws`. This pull request fixes that issue to install the correct package `awscli`.

https://pypi.org/project/aws/
https://pypi.org/project/awscli/
