### PR TITLE
Make install more intelligent.

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -24,13 +24,16 @@ executors:
 
 commands:
   install:
-    description: |
-      Install the AWS CLI via pip.
-
+    description: "Install the AWS CLI via Pip if not already installed."
     steps:
       - run:
-          name: Install AWS CLI
+          name: "Install AWS CLI"
           command: |
+            if which aws > /dev/null; then
+              echo "The AWS CLI is already installed. Skipping."
+              exit 0
+            fi
+
             export PIP=$(which pip pip3 | head -1)
             if [[ -n $PIP ]]; then
               if which sudo > /dev/null; then

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 description: |
-  Install and configure the AWS command-line interface (awscli). View 
+  Install and configure the AWS command-line interface (awscli). View
   this orb's source: https://github.com/CircleCI-Public/aws-cli-orb
 
 executors:


### PR DESCRIPTION
Fixes #13.

If the AWS CLI is already installed, the `install` command will now let you know via echo and just exit successfully.