### PR TITLE
Replace "configure" with "setup"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,8 +78,7 @@ jobs:
     executor: aws-cli/default
     steps:
       - checkout
-      - aws-cli/install
-      - aws-cli/configure
+      - aws-cli/setup
 
   dev-promote-prod:
     executor: cli

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -149,4 +149,3 @@ examples:
             jobs:
               - aws-cli-example:
                   context: aws
-    


### PR DESCRIPTION
The install command will now only install when the aws cli is missing. Added this command to the configure command and renamed configure to "setup". Updated read me. Added example