### PR TITLE
feat: add issue and pull request template, based on the ones from the other CircleCI orbs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,25 @@
+---
+title: Bug
+about: A technical problem
+---
+
+### Orb version
+
+<!---
+  e.g., 1.0.0
+  find this information in your config.yml file;
+  if the version is @volatile, check the top of your CircleCI-generated,
+  expanded configuration file, viewable from the "Configuration" tab of
+  any job page, for the orb's specific semantic version number
+-->
+
+### What happened
+
+<!---
+  please include any relevant links to CircleCI workflows or jobs
+  where you saw this behavior
+-->
+
+### Expected behavior
+
+<!--- what should happen, ideally? -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+### Checklist
+
+<!--
+	thank you for contributing to CircleCI Orbs!
+	before submitting your request, please go through the following
+	items and place an x in the [ ] if they have been completed
+-->
+
+- [ ] All new jobs, commands, executors, parameters have descriptions
+- [ ] Examples have been added for any significant new features
+- [ ] README has been updated, if necessary
+
+### Motivation, issues
+
+<!---
+	why is this change required? what problem does it solve?
+  paste links to any relevant GitHub issues filed against
+  this repository that this pull request addresses
+-->
+
+### Description
+
+<!---
+  Describe your changes in detail, preferably in an imperative mood,
+  i.e., "add `commandA` to `jobB`"
+ -->


### PR DESCRIPTION
This MR introduces issue und pull-request templates with the same format as the ones from https://github.com/CircleCI-Public/circleci-orbs/tree/staging/.github.

This increases the UX for CircleCI orbs across the different projects :)