### PR TITLE
Add skip-install-check parameter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,7 +167,6 @@ workflows:
 
       - test-skip-install-check:
           name: test-skip-install-check_dev
-          pre-steps: *integration-pre-steps
           filters: *integration-dev_filters
 
       # triggered by master branch commits
@@ -179,7 +178,6 @@ workflows:
 
       - test-skip-install-check:
           name: test-skip-install-check_master
-          pre-steps: *integration-pre-steps
           filters: *integration-master_filters
 
       - dev-promote-prod:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,7 @@ jobs:
       - aws-cli/setup
 
   test-skip-install-check:
+    # This image is suitable for the test as it comes with aws preinstalled
     machine:
       image: ubuntu-1604:201903-01
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,7 +168,6 @@ workflows:
           name: test-skip-install-check_dev
           pre-steps: *integration-pre-steps
           filters: *integration-dev_filters
-          post-steps: *integration-post-steps
 
       # triggered by master branch commits
       - integration-tests:
@@ -181,7 +180,6 @@ workflows:
           name: test-skip-install-check_master
           pre-steps: *integration-pre-steps
           filters: *integration-master_filters
-          post-steps: *integration-post-steps
 
       - dev-promote-prod:
           context: orb-publishing

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,18 @@ executors:
     docker:
       - image: cibuilds/github
 
+commands:
+  check-latest-version-installed:
+    steps:
+      - run:
+          name: Check that the latest version is installed
+          command: |
+            aws --version
+            if [ "$(pip list --outdated | grep -c "awscli")" -ge 1 ]; then
+              echo "aws version is outdated"
+              exit 1
+            fi
+
 jobs:
   lint:
     executor: lint
@@ -79,6 +91,15 @@ jobs:
     steps:
       - checkout
       - aws-cli/setup
+
+  test-skip-install-check:
+    machine:
+      image: ubuntu-1604:201903-01
+    steps:
+      - checkout
+      - aws-cli/setup:
+          skip-install-check: true
+      - check-latest-version-installed
 
   dev-promote-prod:
     executor: cli
@@ -143,9 +164,21 @@ workflows:
           filters: *integration-dev_filters
           post-steps: *integration-post-steps
 
+      - test-skip-install-check:
+          name: test-skip-install-check_dev
+          pre-steps: *integration-pre-steps
+          filters: *integration-dev_filters
+          post-steps: *integration-post-steps
+
       # triggered by master branch commits
       - integration-tests:
           name: integration-tests_master
+          pre-steps: *integration-pre-steps
+          filters: *integration-master_filters
+          post-steps: *integration-post-steps
+
+      - test-skip-install-check:
+          name: test-skip-install-check_master
           pre-steps: *integration-pre-steps
           filters: *integration-master_filters
           post-steps: *integration-post-steps
@@ -155,3 +188,4 @@ workflows:
           filters: *integration-master_filters
           requires:
             - integration-tests_master
+            - test-skip-install-check_master

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -27,11 +27,17 @@ executors:
 commands:
   install:
     description: "Install the AWS CLI via Pip if not already installed."
+    parameters:
+      skip-install-check:
+        description: |
+          Set to true to skip checking for existing installations before installing.
+        type: boolean
+        default: false
     steps:
       - run:
           name: "Install AWS CLI"
           command: |
-            if which aws > /dev/null; then
+            if [ "<<parameters.skip-install-check>>" == "false" ] && which aws > /dev/null; then
               echo "The AWS CLI is already installed. Skipping."
               exit 0
             fi
@@ -101,8 +107,15 @@ commands:
         type: boolean
         default: true
 
+      skip-install-check:
+        description: |
+          Set to true to skip checking for existing installations before installing.
+        type: boolean
+        default: false
+
     steps:
-      - install
+      - install:
+          skip-install-check: <<parameters.skip-install-check>>
 
       - run:
           name: Configure AWS Access Key ID


### PR DESCRIPTION
Resolves https://github.com/CircleCI-Public/aws-cli-orb/issues/30 by adding an option to skip the installation check. This is useful when an executor image comes with an older version of the aws CLI pre-installed, but the user wishes to use the orb to install the latest version. (Currently the orb would detect the existing installation and skip the install)
