### PR TITLE
fix: when installing v2, set empty AWS_PAGER var [semver:minor]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,23 +44,12 @@ jobs:
       - checkout
       - aws-cli/setup
       - run:
-          name: Test with aws command that requires less
+          name: Test that paging is disabled
           command: |
-            cat > template.yaml \<<-EOF
-            AWSTemplateFormatVersion: '2010-09-09'
-            Resources:
-              myStack:
-                Type: AWS::CloudFormation::Stack
-                Properties:
-                  TemplateURL: https://s3.amazonaws.com/cloudformation-templates-us-east-1/S3_Bucket.template
-                  TimeoutInMinutes: '60'
-            Outputs:
-              StackRef:
-                Value: !Ref myStack
-              OutputFromNestedStack:
-                Value: !GetAtt myStack.Outputs.BucketName
-            EOF
-            TERM=xterm aws cloudformation validate-template --template-body file://template.yaml
+            # Test with aws command that would require paging if a pager is enabled
+            aws ec2 describe-images \
+              --owners amazon \
+              --filters "Name=platform,Values=windows" "Name=root-device-type,Values=ebs"
 
   integration-test-install-v1:
     executor: aws-cli/default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,28 +15,52 @@ parameters:
     type: string
     default: "dev:alpha"
 
+executors:
+  without-less:
+    docker:
+      - image: circleci/python:3.7
+  macos:
+    macos:
+      xcode: 11.4
+  machine:
+    machine:
+      image: ubuntu-1604:202004-01
+
 # Integration tests
 integration_tests: &integration_tests
   [
     integration-test-install-v2,
     integration-test-install-v1,
-    integration-test-skip-install,
-    integration-test-install-v2-macos
+    integration-test-skip-install
   ]
 
 jobs:
   integration-test-install-v2:
-    executor: aws-cli/default
+    parameters:
+      executor:
+        type: executor
+    executor: <<parameters.executor>>
     steps:
       - checkout
       - aws-cli/setup
-
-  integration-test-install-v2-macos:
-    macos:
-      xcode: "11.3.0"
-    steps:
-      - checkout
-      - aws-cli/setup
+      - run:
+          name: Test with aws command that requires less
+          command: |
+            cat > template.yaml \<<-EOF
+            AWSTemplateFormatVersion: '2010-09-09'
+            Resources:
+              myStack:
+                Type: AWS::CloudFormation::Stack
+                Properties:
+                  TemplateURL: https://s3.amazonaws.com/cloudformation-templates-us-east-1/S3_Bucket.template
+                  TimeoutInMinutes: '60'
+            Outputs:
+              StackRef:
+                Value: !Ref myStack
+              OutputFromNestedStack:
+                Value: !GetAtt myStack.Outputs.BucketName
+            EOF
+            aws cloudformation validate-template --template-body file://template.yaml
 
   integration-test-install-v1:
     executor: aws-cli/default
@@ -82,10 +106,12 @@ workflows:
   integration-tests_deploy-prod:
     when: << pipeline.parameters.run-integration-tests >>
     jobs:
-      - integration-test-install-v2
+      - integration-test-install-v2:
+          matrix:
+            parameters:
+              executor: [aws-cli/default, without-less, macos, machine]
       - integration-test-install-v1
       - integration-test-skip-install
-      - integration-test-install-v2-macos
 
       - orb-tools/dev-promote-prod-from-commit-subject:
           orb-name: circleci/aws-cli

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
               OutputFromNestedStack:
                 Value: !GetAtt myStack.Outputs.BucketName
             EOF
-            aws cloudformation validate-template --template-body file://template.yaml
+            TERM=xterm aws cloudformation validate-template --template-body file://template.yaml
 
   integration-test-install-v1:
     executor: aws-cli/default

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -11,6 +11,11 @@ parameters:
       Set to true to skip checking for existing installations before installing.
     type: boolean
     default: false
+  disable-aws-pager:
+    description: |
+      Set to false to skip forceful disabling of output paging if the less command is not installed.
+    type: boolean
+    default: true
 
 steps:
   - run:
@@ -88,28 +93,14 @@ steps:
                   exit 1
               esac
 
-              # Install `less` for paging if not present
+              # If `less` is not installed and AWS_PAGER is not set explicitly
+              # override with the empty string so that certain commands do not fail.
 
-              if [ -z "$(command -v less)" ]; then
-                case $SYS_ENV_PLATFORM in
-                  linux)
-                    if [ -x "$(command -v apt-get)" ]; then
-                      $SUDO apt-get update && $SUDO apt-get install -y less
-                    else
-                      echo "Unable to install missing less command on this platform."
-                    fi
-                    ;;
-                  *)
-                    echo "Unable to install missing less command on this platform."
-                esac
-              fi
-
-              # Print message on how to work around missing paging command if
-              # it could not be installed
-
-              if [ -z "$(command -v less)" ]; then
-                echo "AWS CLI V2 requires the less command for paging, but it could not be found or installed."
-                echo "You can set the AWS_PAGER environment variable to point at a different command."
+              if [ "<<parameters.disable-aws-pager>>" == "true" && -z "$(command -v less)" && -z "${AWS_PAGER}"]; then
+                echo 'export AWS_PAGER=""' >> $BASH_ENV
+                echo "AWS CLI V2 expects the less command to be installed for paging, but it could not be found."
+                echo "AWS_PAGER is therefore now being set to the empty string."
+                echo "You can set the `disable-aws-pager` parameter to `false` to disable this behavior."
               fi
 
               # Installation check

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -95,7 +95,7 @@ steps:
 
               # Unless the user indicates otherwise set AWS_PAGER to the empty string
 
-              if [ "<<parameters.disable-aws-pager>>" == "true" && -z "${AWS_PAGER}" ]; then
+              if [ "<<parameters.disable-aws-pager>>" == "true" ] && [ -z "${AWS_PAGER}" ]; then
                 echo 'export AWS_PAGER=""' >> $BASH_ENV
                 echo "AWS_PAGER is being set to the empty string to disable all output paging for AWS CLI commands."
                 echo "You can set the `disable-aws-pager` parameter to `false` to disable this behavior."

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -13,7 +13,7 @@ parameters:
     default: false
   disable-aws-pager:
     description: |
-      Set to false to skip forceful disabling of output paging if the less command is not installed.
+      Set to false to skip forceful disabling of all AWS CLI output paging.
     type: boolean
     default: true
 
@@ -93,13 +93,11 @@ steps:
                   exit 1
               esac
 
-              # If `less` is not installed and AWS_PAGER is not set explicitly
-              # override with the empty string so that certain commands do not fail.
+              # Unless the user indicates otherwise set AWS_PAGER to the empty string
 
-              if [ "<<parameters.disable-aws-pager>>" == "true" && -z "$(command -v less)" && -z "${AWS_PAGER}"]; then
+              if [ "<<parameters.disable-aws-pager>>" == "true" && -z "${AWS_PAGER}" ]; then
                 echo 'export AWS_PAGER=""' >> $BASH_ENV
-                echo "AWS CLI V2 expects the less command to be installed for paging, but it could not be found."
-                echo "AWS_PAGER is therefore now being set to the empty string."
+                echo "AWS_PAGER is being set to the empty string to disable all output paging for AWS CLI commands."
                 echo "You can set the `disable-aws-pager` parameter to `false` to disable this behavior."
               fi
 

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -94,7 +94,7 @@ steps:
                 case $SYS_ENV_PLATFORM in
                   linux)
                     if [ -x "$(command -v apt-get)" ]; then
-                      $SUDO apt-get install less
+                      $SUDO apt-get update && $SUDO apt-get install -y less
                     else
                       echo "Unable to install missing less command on this platform."
                     fi

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -88,6 +88,30 @@ steps:
                   exit 1
               esac
 
+              # Install `less` for paging if not present
+
+              if [ -z "$(command -v less)" ]; then
+                case $SYS_ENV_PLATFORM in
+                  linux)
+                    if [ -x "$(command -v apt-get)" ]; then
+                      $SUDO apt-get install less
+                    else
+                      echo "Unable to install missing less command on this platform."
+                    fi
+                    ;;
+                  *)
+                    echo "Unable to install missing less command on this platform."
+                esac
+              fi
+
+              # Print message on how to work around missing paging command if
+              # it could not be installed
+
+              if [ -z "$(command -v less)" ]; then
+                echo "AWS CLI V2 requires the less command for paging, but it could not be found or installed."
+                echo "You can set the AWS_PAGER environment variable to point at a different command."
+              fi
+
               # Installation check
 
               if aws --version &> grep -q "aws-cli/2"; then

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -98,7 +98,7 @@ steps:
               if [ "<<parameters.disable-aws-pager>>" == "true" ] && [ -z "${AWS_PAGER}" ]; then
                 echo 'export AWS_PAGER=""' >> $BASH_ENV
                 echo "AWS_PAGER is being set to the empty string to disable all output paging for AWS CLI commands."
-                echo "You can set the `disable-aws-pager` parameter to `false` to disable this behavior."
+                echo "You can set the 'disable-aws-pager' parameter to 'false' to disable this behavior."
               fi
 
               # Installation check

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -93,14 +93,6 @@ steps:
                   exit 1
               esac
 
-              # Unless the user indicates otherwise set AWS_PAGER to the empty string
-
-              if [ "<<parameters.disable-aws-pager>>" == "true" ] && [ -z "${AWS_PAGER}" ]; then
-                echo 'export AWS_PAGER=""' >> $BASH_ENV
-                echo "AWS_PAGER is being set to the empty string to disable all output paging for AWS CLI commands."
-                echo "You can set the 'disable-aws-pager' parameter to 'false' to disable this behavior."
-              fi
-
               # Installation check
 
               if aws --version &> grep -q "aws-cli/2"; then
@@ -116,3 +108,15 @@ steps:
             exit 1
           ;;
         esac
+
+  - when:
+      condition: <<parameters.disable-aws-pager>>
+      steps:
+        - run:
+            name: Disable AWS pager if not already configured
+            command: |
+              if [ -z "${AWS_PAGER}" ]; then
+                echo 'export AWS_PAGER=""' >> $BASH_ENV
+                echo "AWS_PAGER is being set to the empty string to disable all output paging for AWS CLI commands."
+                echo "You can set the 'disable-aws-pager' parameter to 'false' to disable this behavior."
+              fi

--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -49,10 +49,17 @@ parameters:
     type: boolean
     default: false
 
+  disable-aws-pager:
+    description: |
+      Set to false to skip forceful disabling of all AWS CLI output paging.
+    type: boolean
+    default: true
+
 steps:
   - install:
       skip-install-check: <<parameters.skip-install-check>>
       version: <<parameters.version>>
+      disable-aws-pager: <<parameters.disable-aws-pager>>
 
   - run:
       name: Configure AWS Access Key ID


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

As seen in https://github.com/CircleCI-Public/aws-cli-orb/issues/41, a breaking change in AWS CLI v2 is that it now relies on a paging command to be installed on the system: https://docs.aws.amazon.com/cli/latest/userguide/cliv2-migration.html#cliv2-migration-output-pager

By default it looks for `less` on *ix systems. Some CircleCI images (or custom images) do not have this command installed by default (this happened to me with `circleci/python:3.7`) which will have some `aws` commands fail with:

```
[Errno 2] No such file or directory: 'less': 'less'
```
A broken public build can be found here: https://app.circleci.com/pipelines/github/offen/docs/92/workflows/e6f75939-12b0-4ff8-a41a-613d7349f9a6/jobs/62


### Description

This PR checks whether `less` is installed and in case it isn't and it can install it (i.e. the OS is Linux and `apt-get` is available), it will install the command.

After doing so another check is performed an a message about a possible workaround using `AWS_PAGER` is printed in case the command is still not present.