### PR TITLE
Support overwriting existing v2 installation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,9 @@ executors:
   python:
     docker:
       - image: cimg/python:3.8
+  awsv2preinstalled:
+    docker:
+      - image: cibuilds/aws:2.0.6
   macos:
     macos:
       xcode: 11.4
@@ -143,7 +146,7 @@ workflows:
       - integration-test-install-v2:
           matrix:
             parameters:
-              executor: [aws-cli/default, without-less, macos, machine, python]
+              executor: [aws-cli/default, without-less, macos, machine, python, awsv2preinstalled]
       - integration-test-install-v1:
           matrix:
             parameters:

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -48,6 +48,11 @@ steps:
             echo "Skipping version check. Installing CLI"
         fi
 
+        AWS_V2_UPDATE_PARAM=""
+        if aws --version 2>&1 | grep -q $AWS_VER_REGEXP_2; then
+            AWS_V2_UPDATE_PARAM="--update"
+        fi
+
         #If the desired version of the CLI is not installed, install it.
         if [[ $AWS_CLI_VERSION_SELECTED != $AWS_CLI_INSTALLED_VERSION ]]; then
 
@@ -58,7 +63,7 @@ steps:
             fi
             case $AWS_CLI_VERSION_SELECTED in
                 "1")
-                    if ! which python; then
+                    if ! command -v python >/dev/null 2>&1 && ! command -v python3 >/dev/null 2>&1 ; then
                         echo "Your environment does not seem to have Python installed, a requirement of the AWS CLI."
                         echo "Please either utilize the AWS CLI v2, or select an envionment with Python installed."
                         echo "Recommended image: cimg:/python:3.8"
@@ -118,7 +123,7 @@ steps:
                         linux)
                             curl -sSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
                             unzip awscliv2.zip
-                            $SUDO ./aws/install
+                            $SUDO ./aws/install $AWS_V2_UPDATE_PARAM
                             rm awscliv2.zip
                             ;;
                         darwin)


### PR DESCRIPTION
Changes:
- Add an executor with aws v2 preinstalled, to the integration tests
- Fix behavior of orb when there is an existing v2 installation by adding `--update` flag when needed (see https://github.com/CircleCI-Public/aws-cli-orb/commit/68876240873e0fb5bd247924e174682f0756bcbd for example of error when `--update` is not set)
- Also detect `python3`