### PR TITLE
add brackets for if statement check [semver:patch]

### DIFF
--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -30,7 +30,7 @@ steps:
 
         if [[ $EUID == 0 ]]; then export SUDO=""; else export SUDO="sudo"; fi
 
-        if "<<parameters.skip-install-check>>" == "false"; then
+        if [ "<<parameters.skip-install-check>>" == "false" ]; then
             if ! command -v aws --version >/dev/null 2>&1  ; then
                 echo AWS is not installed
             else


### PR DESCRIPTION
### Checklist
- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

This is a proposed fix for the following issue:

https://github.com/CircleCI-Public/aws-cli-orb/issues/50

I believe the newly implemented if/else statement was always resulting in the `else` and causing failed builds when the AWS CLI tool was already installed.

### Description

This change adds brackets around the conditional to check if the `skip-install-check` parameter is false to ensure the check is made and the right part of the code is executed. 

### Before (With version `1.2` I am seeing):

![aws_before](https://user-images.githubusercontent.com/19393321/86420921-b45b6f80-bc9d-11ea-9bd9-3aa08edeee81.png)

### After (With my dev version from this PR I am seeing)

![aws_after](https://user-images.githubusercontent.com/19393321/86420671-f801a980-bc9c-11ea-961f-af5086cfd28f.png)
