### PR TITLE
Bugfix: Properly pipe output to grep and avoid creating unnecessary file

### DIFF
--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -95,7 +95,7 @@ steps:
                         exit 1
                     fi
                     # Installation check
-                    if aws --version &> grep -q "aws-cli/1"; then
+                    if aws --version &> | grep -q "aws-cli/1"; then
                         echo "AWS CLI V1 has been installed successfully"
                         exit 0
                     else
@@ -138,7 +138,7 @@ steps:
                         ;;
                     esac
                     # Installation check
-                    if aws --version &> grep -q "aws-cli/2"; then
+                    if aws --version &> | grep -q "aws-cli/2"; then
                         echo "AWS CLI V2 has been installed successfully"
                         exit 0
                     else


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

Without the pipe, a file called "grep" is created. This can cause issues
with customer scripts that check the file system's state, such as
`git status --porcelain`.

### Description

Properly pipe output to grep and avoid creating unnecessary file

