### PR TITLE
[semver:patch] Quieten unzip output

### DIFF
--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -81,7 +81,7 @@ steps:
                     elif [[ $(which unzip curl | wc -l) -eq 2 ]]; then
                         cd
                         curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
-                        unzip awscli-bundle.zip
+                        unzip -q awscli-bundle.zip
                         if which sudo > /dev/null; then
                             sudo ~/awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
                         else
@@ -122,7 +122,7 @@ steps:
                     case $SYS_ENV_PLATFORM in
                         linux)
                             curl -sSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-                            unzip awscliv2.zip
+                            unzip -q awscliv2.zip
                             $SUDO ./aws/install $AWS_V2_UPDATE_PARAM
                             rm awscliv2.zip
                             ;;


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

Installing awscli v2 generates so much output you can't even view it in the CircleCI web UI

```
Your output is too large to display in the browser.

Only the last 400000 characters are displayed.
```

### Description

Quieten unzip output.
