### PR TITLE
[semver:patch] Make orb 'nounset' safe

### DIFF
--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -158,7 +158,7 @@ steps:
         - run:
             name: Disable AWS pager if not already configured
             command: |
-              if [ -z "${AWS_PAGER:-}" ]; then
+              if [ -z "${AWS_PAGER+x}" ]; then
                 echo 'export AWS_PAGER=""' >> $BASH_ENV
                 echo "AWS_PAGER is being set to the empty string to disable all output paging for AWS CLI commands."
                 echo "You can set the 'disable-aws-pager' parameter to 'false' to disable this behavior."

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -71,7 +71,7 @@ steps:
                     fi
                     # install CLI v1
                     export PIP=$(which pip pip3 | head -1)
-                    if [[ -n $PIP ]]; then
+                    if [[ -n "${PIP:-}" ]]; then
                         if which sudo > /dev/null; then
                             sudo $PIP install awscli --upgrade
                         else
@@ -158,7 +158,7 @@ steps:
         - run:
             name: Disable AWS pager if not already configured
             command: |
-              if [ -z "${AWS_PAGER}" ]; then
+              if [ -z "${AWS_PAGER:-}" ]; then
                 echo 'export AWS_PAGER=""' >> $BASH_ENV
                 echo "AWS_PAGER is being set to the empty string to disable all output paging for AWS CLI commands."
                 echo "You can set the 'disable-aws-pager' parameter to 'false' to disable this behavior."


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

We have `set -u` set on all CI steps, which fails when this orb checks if `AWS_PAGER` is set

### Description

Update checking existence of bash variables with `${FOO:-}` syntax
