### PR TITLE
Fix install errors when AWS_PROFILE is set [semver:patch]

### DIFF
--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -95,7 +95,7 @@ steps:
                         exit 1
                     fi
                     # Installation check
-                    if aws --version &> grep -q "aws-cli/1"; then
+                    if env -u AWS_PROFILE aws --version &> grep -q "aws-cli/1"; then
                         echo "AWS CLI V1 has been installed successfully"
                         exit 0
                     else


### PR DESCRIPTION
* When AWS_PROFILE is set in the environment, aws-cli version 1 will error when `aws --version` is run prior to that profile being configured.
  Avoid this by unsetting AWS_PROFILE when running `aws --version`.

### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
