### PR TITLE
[semver:minor] added an option to configure a region for a non-default profile

### DIFF
--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -101,7 +101,7 @@ steps:
         - run:
             name: Configure AWS profile region
             command: |
-              aws configure set <<parameters.profile-name>>.region $<<parameters.aws-region>> \
+              aws configure set region $<<parameters.aws-region>> \
                 --profile <<parameters.profile-name>>
 
   - when:

--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -43,6 +43,12 @@ parameters:
     type: boolean
     default: true
 
+  configure-profile-region:
+    description: |
+      Boolean whether to configure the region for the custom (non-default) profile or not
+    type: boolean
+    default: true
+
   disable-aws-pager:
     description: |
       Set to false to skip forceful disabling of all AWS CLI output paging.
@@ -87,6 +93,15 @@ steps:
             name: Configure AWS default region
             command: |
               aws configure set default.region $<<parameters.aws-region>> \
+                --profile <<parameters.profile-name>>
+
+  - when:
+      condition: <<parameters.configure-profile-region>>
+      steps:
+        - run:
+            name: Configure AWS profile region
+            command: |
+              aws configure set <<parameters.profile-name>>.region $<<parameters.aws-region>> \
                 --profile <<parameters.profile-name>>
 
   - when:


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

I'm persisting the .aws folder to the workspace to reuse ready profiles in other jobs. Unfortunately in the current setup, there are only credentials that are set for the profile. The region remains unset for the profile (it's set only for default profile).


### Description

add an option to configure a region for a non-default profile
add a parameter configure-profile-region that works in the same fashion as configure-default-region.
add a step "Configure AWS profile region" that works in the same fashion as "Configure AWS default region".
 