### PR TITLE
[semver:patch] Combine two setup steps into one

### DIFF
--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -73,15 +73,11 @@ steps:
       skip-install-check: <<parameters.skip-install-check>>
 
   - run:
-      name: Configure AWS Access Key ID
+      name: Configure AWS credentials
       command: |
         aws configure set aws_access_key_id \
           $<<parameters.aws-access-key-id>> \
           --profile <<parameters.profile-name>>
-
-  - run:
-      name: Configure AWS Secret Access Key
-      command: |
         aws configure set aws_secret_access_key \
           $<<parameters.aws-secret-access-key>> \
           --profile <<parameters.profile-name>>


### PR DESCRIPTION
Reduce the number of steps this orb adds to jobs.

I would also like to combine the region/default region steps into this step. Are you OK with that?

### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

Running this command generates a LOT of steps in your CircleCI job. It can overpower user-defined steps. This orb should aim to be less visible to end-users.

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

Combine two steps in `aws-cli/setup`.