### PR TITLE
[semver:patch] set AWS_SYMLINK_PATH only when AWS_PATH is symlink

### DIFF
--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -11,7 +11,7 @@ if [ ! "$(which aws)" ] || [ "$PARAM_AWS_CLI_OVERRIDE" = 1 ]; then
             EXISTING_AWS_VERSION=$(aws --version)
             echo "Uninstalling ${EXISTING_AWS_VERSION}"
             # shellcheck disable=SC2012
-            if [ -L "AWS_CLI_PATH" ]; then
+            if [ -L "$AWS_CLI_PATH" ]; then
                 AWS_SYMLINK_PATH=$(ls -l "$AWS_CLI_PATH" | sed -e 's/.* -> //')
             fi
             $SUDO rm -rf "$AWS_CLI_PATH" "$AWS_SYMLINK_PATH" "$HOME/.aws/" "/usr/local/bin/aws" "/usr/local/bin/aws_completer" "/usr/local/aws-cli"

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -11,7 +11,9 @@ if [ ! "$(which aws)" ] || [ "$PARAM_AWS_CLI_OVERRIDE" = 1 ]; then
             EXISTING_AWS_VERSION=$(aws --version)
             echo "Uninstalling ${EXISTING_AWS_VERSION}"
             # shellcheck disable=SC2012
-            AWS_SYMLINK_PATH=$(ls -l "$AWS_CLI_PATH" | sed -e 's/.* -> //')
+            if [ -L "AWS_CLI_PATH" ]; then
+                AWS_SYMLINK_PATH=$(ls -l "$AWS_CLI_PATH" | sed -e 's/.* -> //')
+            fi
             $SUDO rm -rf "$AWS_CLI_PATH" "$AWS_SYMLINK_PATH" "$HOME/.aws/" "/usr/local/bin/aws" "/usr/local/bin/aws_completer" "/usr/local/aws-cli"
         else
             echo "No AWS install found"


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
  - nothing new is added
- [x] Examples have been added for any significant new features
  - no new features
- [x] README has been updated, if necessary
  - not necessary

### Motivation, issues
I met a bug when running `install` with `override-installed: true` .
When `$AWS_PATH` is NOT actually a symbolic link, removing `$AWS_SYMLINK_PATH` fails because of the following error:
`rm: invalid option -- 'w'`
This is caused because `sed` command does not work as expected and `$AWS_SYMLINK_PATH` starts with the permissions like `-rwx...` .

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description
`$AWS_SYMLINK_PATH` will be set only when `$AWS_PATH` is symlink, so that an empty string will be passed to `rm` command otherwise.

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
