### PR TITLE
[semver:patch] Fixed a typo in the message when cli is already installed.

### DIFF
--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -66,6 +66,6 @@ if [ ! "$(which aws)" ] || [ "$PARAM_AWS_CLI_OVERRIDE" = 1 ]; then
         fi
     fi
 else
-    echo "AWS CLI is already installed, skipping isntallation."
+    echo "AWS CLI is already installed, skipping installation."
     aws --version
 fi


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

I found a typo while looking at the CI execution log.

### Description

Fixed a typo.

`AWS CLI is already installed, skipping isntallation.`
↓
`AWS CLI is already installed, skipping installation.`

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
