### PR TITLE
Add parameters to customize installation and binary directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ jobs:
     executor: aws-cli/default
     steps:
       - checkout
+      - aws-cli/install:
+        install-dir: ~/.local/aws
+        binary-dir: ~/.local/bin
       - aws-cli/setup:
           profile-name: example
       - run: echo "Run your code here"

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -24,4 +24,6 @@ steps:
         PARAM_AWS_CLI_VERSION: <<parameters.version>>
         PARAM_AWS_CLI_DISABLE_PAGER: <<parameters.disable-aws-pager>>
         PARAM_AWS_CLI_OVERRIDE: <<parameters.override-installed>>
+        PARAM_AWS_CLI_INSTALL_DIR: <<parameters.install-dir>>
+        PARAM_AWS_CLI_BINARY_DIR: <<parameters.binary-dir>>
       command: <<include(scripts/install.sh)>>

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -1,3 +1,6 @@
+export PARAM_AWS_CLI_INSTALL_DIR="${PARAM_AWS_CLI_INSTALL_DIR:=/usr/local/aws-cli}"
+export PARAM_AWS_CLI_BINARY_DIR="${PARAM_AWS_CLI_BINARY_DIR:=/usr/local/bin}"
+
 if [[ $EUID == 0 ]]; then export SUDO=""; else export SUDO="sudo"; fi
 
 if [ ! "$(which aws)" ] || [ "$PARAM_AWS_CLI_OVERRIDE" = 1 ]; then
@@ -40,7 +43,7 @@ if [ ! "$(which aws)" ] || [ "$PARAM_AWS_CLI_OVERRIDE" = 1 ]; then
     linux_x86)
         curl -sSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64${AWS_CLI_VER_STRING}.zip" -o "awscliv2.zip"
         unzip -q -o awscliv2.zip
-        $SUDO ./aws/install
+        $SUDO ./aws/install -i $PARAM_AWS_CLI_INSTALL_DIR -b $PARAM_AWS_CLI_BINARY_DIR
         rm awscliv2.zip
         ;;
     macos)
@@ -51,7 +54,7 @@ if [ ! "$(which aws)" ] || [ "$PARAM_AWS_CLI_OVERRIDE" = 1 ]; then
     linux_arm)
         curl -sSL "https://awscli.amazonaws.com/awscli-exe-linux-aarch64${AWS_CLI_VER_STRING}.zip" -o "awscliv2.zip"
         unzip -q -o awscliv2.zip
-        $SUDO ./aws/install
+        $SUDO ./aws/install -i $PARAM_AWS_CLI_INSTALL_DIR -b $PARAM_AWS_CLI_BINARY_DIR
         rm awscliv2.zip
         ;;
     *)


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

Some workflows require the aws cli to be installed on a custom directory.

The installation command supports flag to specify custom installation and binary directories:
https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html

### Description

This PR adds parameters to specify installation and binary directories to the `aws-cli/install` command. 
