### PR TITLE
Revert "[semver:patch] docs: update description on installing AWS CLI"

### DIFF
--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -1,4 +1,4 @@
-description: "Install the AWS CLI if not already installed."
+description: "Install the AWS CLI via Pip if not already installed."
 
 parameters:
   version:


### PR DESCRIPTION
We don't actually use pip to install the CLI anymore. Oops.

Reverts CircleCI-Public/aws-cli-orb#87