### PR TITLE
[semver:minor] Added  support for role-arn configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,7 +171,7 @@ workflows:
                 version: "2.0.20"
       - integration-test-role-arn-setup:
           name: test-role-arn-config
-          profile-name: "CircleCI Tester"
+          profile-name: "CircleCI-Tester"
           role-arn: "arn:aws:iam::0123456789:role/foo-bar"
 
       # Publish a semver version of the orb. relies on

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,8 +88,7 @@ jobs:
         description: Role ARN that the profile should take.
         type: string
       source-profile:
-        description: |
-          Source profile containing credentials to assume the role with role-arn.
+        description: Source profile containing credentials to assume the role with role-arn.
         type: string
         default: "default"
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ jobs:
       - aws-cli/setup:
           version: <<parameters.version>>
       - test-paging
-  
+
   integration-test-role-arn-setup:
     executor: docker-base
     parameters:
@@ -88,7 +88,7 @@ jobs:
         description: Role ARN that the profile should take.
         type: string
       source-profile:
-        description: | 
+        description: |
           Source profile containing credentials to assume the role with role-arn.
         type: string
         default: "default"

--- a/src/commands/role-arn-setup.yml
+++ b/src/commands/role-arn-setup.yml
@@ -28,8 +28,7 @@ parameters:
       type: string
 
   source-profile:
-      description: |
-        Source profile containing credentials to assume the role with role-arn.
+      description: Source profile containing credentials to assume the role with role-arn.
       type: string
       default: "default"
 

--- a/src/commands/role-arn-setup.yml
+++ b/src/commands/role-arn-setup.yml
@@ -28,7 +28,7 @@ parameters:
       type: string
 
   source-profile:
-      description: | 
+      description: |
         Source profile containing credentials to assume the role with role-arn.
       type: string
       default: "default"

--- a/src/scripts/role-arn-setup.sh
+++ b/src/scripts/role-arn-setup.sh
@@ -4,4 +4,4 @@ PARAM_AWS_CLI_SOURCE_PROFILE=$(eval echo "${PARAM_AWS_CLI_SOURCE_PROFILE}")
 PARAM_AWS_CLI_ROLE_ARN=$(eval echo "${PARAM_AWS_CLI_ROLE_ARN}")
 
 aws configure set profile."${PARAM_AWS_CLI_PROFILE_NAME}".role_arn "${PARAM_AWS_CLI_ROLE_ARN}"
-aws configure set profile."${PARAM_AWS_CLI_PROFILE_NAME}".source_profile default "${PARAM_AWS_CLI_SOURCE_PROFILE}"
+aws configure set profile."${PARAM_AWS_CLI_PROFILE_NAME}".source_profile "${PARAM_AWS_CLI_SOURCE_PROFILE}"


### PR DESCRIPTION
This update adds a new command called `role-arn-setup` that lets users create a new profile attached to a specific arn and takes the credentials of a source profile