### PR TITLE
fix: correct role-arn-setup step typo [semver:patch]

### DIFF
--- a/src/commands/role-arn-setup.yml
+++ b/src/commands/role-arn-setup.yml
@@ -35,7 +35,7 @@ parameters:
 steps:
 
   - run:
-      name: Configure role arn for profie <<parameters.profile-name>>
+      name: Configure role arn for profile <<parameters.profile-name>>
       environment:
         PARAM_AWS_CLI_PROFILE_NAME: <<parameters.profile-name>>
         PARAM_AWS_CLI_SOURCE_PROFILE: <<parameters.source-profile>>


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Description

Tiny typo I noticed when using the changes from #91!
