### PR TITLE
Cleaning up the files after installation

### DIFF
--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -42,7 +42,7 @@ if [ ! "$(which aws)" ] || [ "$PARAM_AWS_CLI_OVERRIDE" = 1 ]; then
         curl -sSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64${AWS_CLI_VER_STRING}.zip" -o "awscliv2.zip"
         unzip -q -o awscliv2.zip
         $SUDO ./aws/install
-        rm awscliv2.zip
+        rm -r awscliv2.zip ./aws
         ;;
     macos)
         curl -sSL "https://awscli.amazonaws.com/AWSCLIV2${AWS_CLI_VER_STRING}.pkg" -o "AWSCLIV2.pkg"
@@ -53,7 +53,7 @@ if [ ! "$(which aws)" ] || [ "$PARAM_AWS_CLI_OVERRIDE" = 1 ]; then
         curl -sSL "https://awscli.amazonaws.com/awscli-exe-linux-aarch64${AWS_CLI_VER_STRING}.zip" -o "awscliv2.zip"
         unzip -q -o awscliv2.zip
         $SUDO ./aws/install
-        rm awscliv2.zip
+        rm -r awscliv2.zip ./aws
         ;;
     *)
         echo "This orb does not currently support your platform. If you believe it should, please consider opening an issue on the GitHub repository:"


### PR DESCRIPTION
The current orb leaves behind the `aws` directory in the working path, these files are not needed once aws-cli is installed in the system

### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

Leaving behind some installation artefacts is a bad practice and it could lead to these artefacts ending up docker images if the same working directory is used to build a docker image.

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description

Remove the content of the installation zip file at the same time as removing the zip file itself. 

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
