### PR TITLE
[semver:skip] Enabling publishing version tag to repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,7 +185,7 @@ workflows:
           context: orb-publisher
           add-pr-comment: false
           fail-if-semver-not-indicated: true
-          publish-version-tag: false
+          publish-version-tag: true
           requires:
             - integration-test-install
             - integration-test-install-version


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [ ] n/a - All new jobs, commands, executors, parameters have descriptions
- [ ] n/a - Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

As a user of this orb, I've seen the versioning on the orb documentation, but I can never find it in this repo. So for example, I have a pipeline using v2.0.6 of this orb, but I see v2.1.0 is published - but I have no idea what is different between them. I have to sort of go scour through the merged PRs in this repo, and try to figure out which semver bumps did which, to figure that out.

Ideally, this orb could likely use a `CHANGELOG.md` which tracks the versions, but I think a small incremental update is turning the existing orb dev key feature of publishing the version as a tag to the repo. At least then I can see the difference, and do a commit diff between versions to see the exact changes.

It was originally on in this repo, but reverted as part of the v2.0 launched via PR https://github.com/CircleCI-Public/aws-cli-orb/pull/70.  I don't know if it was intentional, or inadvertent, but I like it and think it will hep users of this orb, so proposing to turn it back on!

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

Changes the pipeline for this orb to publish release tags to GitHub.

## Screen shots

tags:
<img width="607" alt="image" src="https://user-images.githubusercontent.com/33203301/157708339-789267c0-5c8f-49d9-b5d9-5eede9cd3707.png">

orb docs say v2.1 is out:
<img width="980" alt="image" src="https://user-images.githubusercontent.com/33203301/157708428-75f23bc4-22cc-46b8-8fb1-fde68bbb8ed6.png">

try to figure out what changed between v2.0.6 and v2.1:
<img width="698" alt="image" src="https://user-images.githubusercontent.com/33203301/157708569-22f7f503-8046-46cb-8981-d5523b2e784b.png">
