### PR TITLE
[semver:skip] Fix typo in Role ARN Setup command documentation

### DIFF
--- a/src/commands/role-arn-setup.yml
+++ b/src/commands/role-arn-setup.yml
@@ -35,7 +35,7 @@ parameters:
 steps:
 
   - run:
-      name: Configure role arn for profie <<parameters.profile-name>>
+      name: Configure role arn for profile <<parameters.profile-name>>
       environment:
         PARAM_AWS_CLI_PROFILE_NAME: <<parameters.profile-name>>
         PARAM_AWS_CLI_SOURCE_PROFILE: <<parameters.source-profile>>


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

🧹 quality!

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

Fixes a minor typo in the Role ARN Setup command documentation.