### PR TITLE
Ensure proper routing of empty aws-cli versions

### DIFF
--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -121,7 +121,7 @@ Uninstall_AWS_CLI() {
 }
 
 if [ ! "$(command -v aws)" ]; then
-    if [ "$PARAM_AWS_CLI_VERSION" = "latest" ]; then
+    if [ -n "$PARAM_AWS_CLI_VERSION" ] || [ "$PARAM_AWS_CLI_VERSION" = "latest" ]; then
         Install_AWS_CLI
     else
         if uname -a | grep "x86_64 Msys"; then


### PR DESCRIPTION
Treat an empty version string the same as "latest"

### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

In some cases the `$PARAM_AWS_CLI_VERSION` that gets to `install.sh` ends up being empty. There is an additional task here to figure out why the version parameter's default isn't making its way to the `install.sh` script, but this is simply an additional condition check so we're not routing that empty version string to the wrong `Install_AWS_CLI()` call. Otherwise we end up with an `Install_AWS_CLI("-")` call that will fail in a not-immediately-discernable way.

### Description

add a check for empty version strings when installing
