### PR TITLE
fix: double-quote parameters given to assume-role-with-web-identity

### DIFF
--- a/src/scripts/assume-role-with-web-identity.sh
+++ b/src/scripts/assume-role-with-web-identity.sh
@@ -8,10 +8,10 @@ fi
 
 # shellcheck disable=SC2086,SC2034
 read -r AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN <<<"$(aws sts assume-role-with-web-identity \
-    --role-arn ${PARAM_AWS_CLI_ROLE_ARN} \
-    --role-session-name ${PARAM_ROLE_SESSION_NAME} \
-    --web-identity-token ${CIRCLE_OIDC_TOKEN} \
-    --duration-seconds ${PARAM_SESSION_DURATION} \
+    --role-arn "${PARAM_AWS_CLI_ROLE_ARN}" \
+    --role-session-name "${PARAM_ROLE_SESSION_NAME}" \
+    --web-identity-token "${CIRCLE_OIDC_TOKEN}" \
+    --duration-seconds "${PARAM_SESSION_DURATION}" \
     --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' \
     --output text)"
 


### PR DESCRIPTION
Prevent globbing and word splitting

### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

https://github.com/CircleCI-Public/aws-cli-orb/issues/104

When session name contains spaces, assuming role with web identity fails due to word splitting.

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

While it's a small change, I haven't tested it in the context of the orb—can you help me with that? If it gets published as a dev version, I can make sure that it still works as expected.