### PR TITLE
[semver:skip] Fixing typo in parameter description 

### DIFF
--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -50,7 +50,7 @@ parameters:
     description: |
       AWS secret key for IAM role. Set this to the name of
       the environment variable you will use to hold this
-      value, i.e. $AWS_SECRET_ACCESS_KEY.
+      value, i.e. AWS_SECRET_ACCESS_KEY.
     type: env_var_name
     default: AWS_SECRET_ACCESS_KEY
 


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [ n/a ] All new jobs, commands, executors, parameters have descriptions
- [ n/a ] Examples have been added for any significant new features
- [ n/a ] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->
The `aws-secret-access-key` parameter's description (`setup` command) references the name of the environment variable preceded by `$`, instead of just the environment variable's name. This is incorrect and could create confusion.
### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
Remove the `$` (Dollar sign) that's currently preceding the environment variable's name. 