### PR TITLE
fix: addressed shellcheck errors

### DIFF
--- a/src/scripts/assume-role-with-web-identity.sh
+++ b/src/scripts/assume-role-with-web-identity.sh
@@ -16,13 +16,12 @@ if [ ! "$(command -v aws)" ]; then
     exit 1
 fi
 
-# shellcheck disable=SC2086,SC2034
 read -r AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN <<EOF
 $(aws sts assume-role-with-web-identity \
---role-arn ${PARAM_AWS_CLI_ROLE_ARN} \
---role-session-name ${PARAM_ROLE_SESSION_NAME} \
---web-identity-token ${CIRCLE_OIDC_TOKEN} \
---duration-seconds ${PARAM_SESSION_DURATION} \
+--role-arn "${PARAM_AWS_CLI_ROLE_ARN}" \
+--role-session-name "${PARAM_ROLE_SESSION_NAME}" \
+--web-identity-token "${CIRCLE_OIDC_TOKEN}" \
+--duration-seconds "${PARAM_SESSION_DURATION}" \
 --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' \
 --output text)
 EOF


### PR DESCRIPTION
This `PR` cleans up the `assume-role-with-web-identity` script and addresses the `shellcheck` errors. 