### PR TITLE
fix: source env vars for alpine linux

### DIFF
--- a/src/scripts/configure.sh
+++ b/src/scripts/configure.sh
@@ -8,7 +8,7 @@ PARAM_AWS_CLI_SECRET_ACCESS_KEY=$(eval echo "\$$PARAM_AWS_CLI_SECRET_ACCESS_KEY"
 PARAM_AWS_CLI_REGION=$(eval echo "\$$PARAM_AWS_CLI_REGION")
 
 if [ -z "$PARAM_AWS_CLI_ACCESS_KEY_ID" ] || [ -z "${PARAM_AWS_CLI_SECRET_ACCESS_KEY}" ]; then 
-    echo "Cannot configure profile. AWS access keu id and AWS secret access key must be provided"
+    echo "Cannot configure profile. AWS access key id and AWS secret access key must be provided."
     exit 1
 fi
 

--- a/src/scripts/configure.sh
+++ b/src/scripts/configure.sh
@@ -3,15 +3,14 @@ if cat /etc/issue | grep "Alpine" >/dev/null 2>&1; then
     . $BASH_ENV
 fi
 
-{ 
-    echo "$PARAM_AWS_CLI_ACCESS_KEY_ID"
-}
 PARAM_AWS_CLI_ACCESS_KEY_ID=$(eval echo "\$$PARAM_AWS_CLI_ACCESS_KEY_ID")
 PARAM_AWS_CLI_SECRET_ACCESS_KEY=$(eval echo "\$$PARAM_AWS_CLI_SECRET_ACCESS_KEY")
 PARAM_AWS_CLI_REGION=$(eval echo "\$$PARAM_AWS_CLI_REGION")
-{ 
-    echo "$PARAM_AWS_CLI_ACCESS_KEY_ID"
-}
+
+if [ -z "$PARAM_AWS_CLI_ACCESS_KEY_ID" ] || [ -z "${PARAM_AWS_CLI_SECRET_ACCESS_KEY}" ]; then 
+    echo "Cannot configure profile. AWS access keu id and AWS secret access key must be provided"
+    exit 1
+fi
 
 aws configure set aws_access_key_id \
     "$PARAM_AWS_CLI_ACCESS_KEY_ID" \

--- a/src/scripts/configure.sh
+++ b/src/scripts/configure.sh
@@ -1,6 +1,6 @@
-
+#!/bin/sh
 if cat /etc/issue | grep "Alpine" >/dev/null 2>&1; then
-    source $BASH_ENV
+    . $BASH_ENV
 fi
 
 PARAM_AWS_CLI_ACCESS_KEY_ID=$(eval echo "\$$PARAM_AWS_CLI_ACCESS_KEY_ID")

--- a/src/scripts/configure.sh
+++ b/src/scripts/configure.sh
@@ -1,3 +1,8 @@
+
+if cat /etc/issue | grep "Alpine" >/dev/null 2>&1; then
+    source $BASH_ENV
+fi
+
 PARAM_AWS_CLI_ACCESS_KEY_ID=$(eval echo "\$$PARAM_AWS_CLI_ACCESS_KEY_ID")
 PARAM_AWS_CLI_SECRET_ACCESS_KEY=$(eval echo "\$$PARAM_AWS_CLI_SECRET_ACCESS_KEY")
 PARAM_AWS_CLI_REGION=$(eval echo "\$$PARAM_AWS_CLI_REGION")

--- a/src/scripts/configure.sh
+++ b/src/scripts/configure.sh
@@ -3,9 +3,15 @@ if cat /etc/issue | grep "Alpine" >/dev/null 2>&1; then
     . $BASH_ENV
 fi
 
+{ 
+    echo "$PARAM_AWS_CLI_ACCESS_KEY_ID"
+}
 PARAM_AWS_CLI_ACCESS_KEY_ID=$(eval echo "\$$PARAM_AWS_CLI_ACCESS_KEY_ID")
 PARAM_AWS_CLI_SECRET_ACCESS_KEY=$(eval echo "\$$PARAM_AWS_CLI_SECRET_ACCESS_KEY")
 PARAM_AWS_CLI_REGION=$(eval echo "\$$PARAM_AWS_CLI_REGION")
+{ 
+    echo "$PARAM_AWS_CLI_ACCESS_KEY_ID"
+}
 
 aws configure set aws_access_key_id \
     "$PARAM_AWS_CLI_ACCESS_KEY_ID" \


### PR DESCRIPTION
Alpine linux does not source environment variables in between steps. This `PR` adds that ability