### PR TITLE
feat: allow env variable eval using profile-name

### DIFF
--- a/src/commands/assume-role-with-web-identity.yml
+++ b/src/commands/assume-role-with-web-identity.yml
@@ -22,7 +22,7 @@ parameters:
     default: "3600"
 
   profile-name:
-    description: Profile name for web identity role assumption
+    description: Profile name for web identity role assumption - you can supply an env variable here too
     type: string
     default: "default"
 

--- a/src/scripts/role-arn-setup.sh
+++ b/src/scripts/role-arn-setup.sh
@@ -1,8 +1,12 @@
-PARAM_AWS_CLI_ROLE_ARN=$(eval echo "${PARAM_AWS_CLI_ROLE_ARN}")
+#!/usr/bin/env sh
+
 if [ ! -f "${HOME}/.aws/credentials" ]; then
     echo "Credentials not found. Run setup command before role-arn-setup."
     exit 1
 fi
+
+PARAM_AWS_CLI_PROFILE_NAME=$(eval echo "${PARAM_AWS_CLI_PROFILE_NAME}")
+PARAM_AWS_CLI_ROLE_ARN=$(eval echo "${PARAM_AWS_CLI_ROLE_ARN}")
 
 aws configure set profile."${PARAM_AWS_CLI_PROFILE_NAME}".role_arn "${PARAM_AWS_CLI_ROLE_ARN}"
 aws configure set profile."${PARAM_AWS_CLI_PROFILE_NAME}".source_profile "${PARAM_AWS_CLI_SOURCE_PROFILE}"


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

I have been writing a private orb for my organisation to handle our CloudFormation setup. We found that it would be nice to pull profile-name from a context value to further reduce dependencies on parameters within the CircleCI config file. Obviously this is not supported in its current state.

By allowing eval of the profile-name param/env_var inside the `role-arn-setup` command we can allow this change.

### Description

`role-arn-setup` script now calls `eval` on the `PARAM_AWS_CLI_PROFILE_NAME` variable which is mounted directly from the `profile-name` parameter. Also added shebang to the file and put eval steps after the conditional abort.
