### PR TITLE
fix: added --force-overwrite flag to fix glibc install

### DIFF
--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -66,7 +66,7 @@ Install_AWS_CLI() {
         curl -LO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.34-r0/glibc-bin-2.34-r0.apk
         curl -LO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.34-r0/glibc-i18n-2.34-r0.apk
 
-        apk add --no-cache \
+        apk add --force-overwrite --no-cache \
             glibc-2.34-r0.apk \
             glibc-bin-2.34-r0.apk \
             glibc-i18n-2.34-r0.apk


### PR DESCRIPTION
This `PR` fixes an issue that's causing the installation of the `aws-cli` to fail on `Alpine`.  

The issue is caused by an error with installing `glibc` on linux through `apk`.  