### PR TITLE
feat: update to oidc token v2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ workflows:
           requires:
             [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]
           # Use a context to hold your publishing token.
-          context: orb-publishing
+          context: orb-publisher
           filters: *filters
       # Triggers the next workflow in the Orb Development Kit.
       - orb-tools/continue:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 setup: true
 orbs:
-  orb-tools: circleci/orb-tools@11.1
+  orb-tools: circleci/orb-tools@11.6
   shellcheck: circleci/shellcheck@3.1
 
 filters: &filters
@@ -26,7 +26,7 @@ workflows:
           requires:
             [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]
           # Use a context to hold your publishing token.
-          context: orb-publisher
+          context: orb-publishing
           filters: *filters
       # Triggers the next workflow in the Orb Development Kit.
       - orb-tools/continue:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -1,7 +1,7 @@
 version: 2.1
 orbs:
   aws-cli: circleci/aws-cli@dev:<<pipeline.git.revision>>
-  orb-tools: circleci/orb-tools@11.1
+  orb-tools: circleci/orb-tools@11.6
 filters: &filters
   tags:
     only: /.*/

--- a/src/commands/assume-role-with-web-identity.yml
+++ b/src/commands/assume-role-with-web-identity.yml
@@ -1,5 +1,5 @@
 description: |
-  Generate a shortlived AWS_ACCESS_KEY_ID, AWS_ACCESS_KEY_ID and AWS_SESSION_TOKEN using the $CIRCLE_OIDC_TOKEN.
+  Generate a shortlived AWS_ACCESS_KEY_ID, AWS_ACCESS_KEY_ID and AWS_SESSION_TOKEN using the $CIRCLE_OIDC_TOKEN_V2.
   A properly configured web identity based ARN is also required for configuration.
   Use these keys and create a profile with the aws-cli/setup commands.
   For more information, see the CircleCI OIDC docs: https://circleci.com/docs/2.0/openid-connect-tokens/

--- a/src/scripts/assume-role-with-web-identity.sh
+++ b/src/scripts/assume-role-with-web-identity.sh
@@ -6,7 +6,7 @@ if [ -z "${PARAM_ROLE_SESSION_NAME}" ]; then
     exit 1
 fi
 
-if [ -z "${CIRCLE_OIDC_TOKEN}" ]; then
+if [ -z "${CIRCLE_OIDC_TOKEN_V2}" ]; then
     echo "OIDC Token cannot be found. A CircleCI context must be specified."
     exit 1
 fi
@@ -20,7 +20,7 @@ read -r AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN <<EOF
 $(aws sts assume-role-with-web-identity \
 --role-arn "${PARAM_AWS_CLI_ROLE_ARN}" \
 --role-session-name "${PARAM_ROLE_SESSION_NAME}" \
---web-identity-token "${CIRCLE_OIDC_TOKEN}" \
+--web-identity-token "${CIRCLE_OIDC_TOKEN_V2}" \
 --duration-seconds "${PARAM_SESSION_DURATION}" \
 --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' \
 --output text)


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

A new version of the OIDC token has been published, to allow for additional claims. 

The new value is `org/ORGANIZATION_ID/project/PROJECT_ID/user/USER_ID/vcs-origin/VCS_ORIGIN/vcs-ref/VCS_REF`, a string, where `ORGANIZATION_ID`, `PROJECT_ID`, and `USER_ID` are UUIDs that identify the CircleCI organization, project, and user, respectively. The user is the CircleCI user that caused this job to run. VCS_ORIGIN and VCS_REF are strings that identify the repo URL and reference to the change that caused the job to run.

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

Updated instances of `$CIRCLE_OIDC_TOKEN` to `$CIRCLE_OIDC_TOKEN_V2`, and also updated the orb tools orb version from 11.1 to 11.6