### PR TITLE
fix: add touch to initialize $bash_env

### DIFF
--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -56,8 +56,8 @@ parameters:
 
   region:
     description: |
-      Env var of AWS region to operate in
-      (defaults to AWS_DEFAULT_REGION)
+      AWS region to operate in
+      (defaults to env var of ${AWS_DEFAULT_REGION})
     type: string
     default: ${AWS_DEFAULT_REGION}
 

--- a/src/examples/configure_role_arn.yml
+++ b/src/examples/configure_role_arn.yml
@@ -3,7 +3,7 @@ usage:
   version: 2.1
 
   orbs:
-    aws-cli: circleci/aws-cli@3.1
+    aws-cli: circleci/aws-cli@4.0
 
   jobs:
     configure_role_arn:

--- a/src/examples/install_aws_cli.yml
+++ b/src/examples/install_aws_cli.yml
@@ -3,7 +3,7 @@ usage:
   version: 2.1
 
   orbs:
-    aws-cli: circleci/aws-cli@3.1
+    aws-cli: circleci/aws-cli@4.0
 
   jobs:
     aws-cli-example:

--- a/src/examples/install_aws_cli_with_web_identity.yml
+++ b/src/examples/install_aws_cli_with_web_identity.yml
@@ -6,7 +6,7 @@ usage:
   version: 2.1
 
   orbs:
-    aws-cli: circleci/aws-cli@3.1
+    aws-cli: circleci/aws-cli@4.0
 
   jobs:
     aws-cli-example:

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -1,9 +1,9 @@
 description: |
-  Highly cached minimal Ubuntu docker designed for CircleCI with Python and NodeJS installed.
+  A base Ubuntu Docker image built to run on CircleCI
 parameters:
   tag:
     description: >
-      Select your python version or any of the available tags here: https://hub.docker.com/r/cimg/python.
+      Select your version or any of the available tags here: https://hub.docker.com/r/cimg/base.
     type: string
     default: "current"
 

--- a/src/scripts/configure.sh
+++ b/src/scripts/configure.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 # shellcheck disable=SC1090
 if grep "Alpine" /etc/issue > /dev/null 2>&1; then
+    touch "$BASH_ENV"
     . "$BASH_ENV"
 fi
 


### PR DESCRIPTION
Currently if the in the `config.sh` script, we run `. $BASH_ENV` in `Alpine Linux` to access environment variables passed from a previous step. However, if `$BASH_ENV` has not been created before this script is run, the build fails with this error:

```
/bin/bash: line 3: /tmp/.bash_env-63ff46c43d2fa51fdd8a6998-0-build: No such file or directory
```

To fix this issue, we must run `touch $BASH_ENV` first as suggested in this Discuss post:
https://support.circleci.com/hc/en-us/articles/360048353271-Accessing-BASH-ENV-Results-in-No-such-file-or-directory-
