### PR TITLE
fix: role session name

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -102,7 +102,7 @@ workflows:
             - run:
                 name: Web Identity Test - Logging into ECR
                 command: aws ecr get-login-password --region us-west-2 --profile "OIDC-User" | docker login --username AWS --password-stdin 122211685980.dkr.ecr.us-west-2.amazonaws.com
-      Testing executors that do not AWS pre-installed
+      # Testing executors that do not AWS pre-installed
       - integration-test-install:
           name: integration-test-install-<<matrix.executor>>
           context: [CPE_ORBS_AWS]
@@ -113,7 +113,7 @@ workflows:
           filters: *filters
           post-steps:
             - check_aws_version
-      Test installing specific versions on executors without AWS pre-installed
+      # Test installing specific versions on executors without AWS pre-installed
       - integration-test-install:
           name: integration-test-install-version-<<matrix.executor>>
           context: [CPE_ORBS_AWS]
@@ -126,7 +126,7 @@ workflows:
           post-steps:
             - check_aws_version:
                 version: "2.1.10"
-      Test overriding existing version of AWS pre-installed
+      # Test overriding existing version of AWS pre-installed
       - integration-test-install:
           name: integration-test-install-override-version-<<matrix.executor>>
           context: [CPE_ORBS_AWS]
@@ -155,7 +155,7 @@ workflows:
           pub_type: production
           enable_pr_comment: true
           context: orb-publisher
-          requires: [orb-tools/pack, test-install, test-install-version, test-install-override-version, integration-test-web-identity-profile, integration-test-role_arn-config]
+          requires: [orb-tools/pack, test-install, test-install-version, test-install-override-version, integration test web identity profile, integration-test-role_arn-config]
           filters: *release-filters
 executors:
   alpine:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -102,61 +102,61 @@ workflows:
             - run:
                 name: Web Identity Test - Logging into ECR
                 command: aws ecr get-login-password --region us-west-2 --profile "OIDC-User" | docker login --username AWS --password-stdin 122211685980.dkr.ecr.us-west-2.amazonaws.com
-      # Testing executors that do not AWS pre-installed
-      # - integration-test-install:
-      #     name: integration-test-install-<<matrix.executor>>
-      #     context: [CPE_ORBS_AWS]
-      #     matrix:
-      #       alias: test-install
-      #       parameters:
-      #         executor: ["docker-base", "macos", "alpine"]
-      #     filters: *filters
-      #     post-steps:
-      #       - check_aws_version
-      # Test installing specific versions on executors without AWS pre-installed
-      # - integration-test-install:
-      #     name: integration-test-install-version-<<matrix.executor>>
-      #     context: [CPE_ORBS_AWS]
-      #     matrix:
-      #       alias: test-install-version
-      #       parameters:
-      #         executor: ["docker-base", "macos", "alpine"]
-      #     version: "2.1.10"
-      #     filters: *filters
-      #     post-steps:
-      #       - check_aws_version:
-      #           version: "2.1.10"
-      # Test overriding existing version of AWS pre-installed
-      # - integration-test-install:
-      #     name: integration-test-install-override-version-<<matrix.executor>>
-      #     context: [CPE_ORBS_AWS]
-      #     matrix:
-      #       alias: test-install-override-version
-      #       parameters:
-      #         executor: ["linuxvm", "windows", "arm"]
-      #     version: "2.1.10"
-      #     install_dir: "/usr/local/aws-cli"
-      #     binary_dir: ""
-      #     override_installed: true
-      #     filters: *filters
-      #     post-steps:
-      #       - check_aws_version:
-      #           version: "2.1.10"
-      # - integration-test-role-arn-setup:
-      #     name: integration-test-role_arn-config
-      #     profile_name: "CircleCI-Tester"
-      #     role_arn: ${ROLE_ARN}
-      #     context: [CPE_ORBS_AWS]
-      # - orb-tools/pack:
-      #     filters: *release-filters
-      # - orb-tools/publish:
-      #     orb_name: circleci/aws-cli
-      #     vcs_type: << pipeline.project.type >>
-      #     pub_type: production
-      #     enable_pr_comment: true
-      #     context: orb-publisher
-      #     requires: [orb-tools/pack, test-install, test-install-version, test-install-override-version, integration-test-web-identity-profile, integration-test-role_arn-config]
-      #     filters: *release-filters
+      Testing executors that do not AWS pre-installed
+      - integration-test-install:
+          name: integration-test-install-<<matrix.executor>>
+          context: [CPE_ORBS_AWS]
+          matrix:
+            alias: test-install
+            parameters:
+              executor: ["docker-base", "macos", "alpine"]
+          filters: *filters
+          post-steps:
+            - check_aws_version
+      Test installing specific versions on executors without AWS pre-installed
+      - integration-test-install:
+          name: integration-test-install-version-<<matrix.executor>>
+          context: [CPE_ORBS_AWS]
+          matrix:
+            alias: test-install-version
+            parameters:
+              executor: ["docker-base", "macos", "alpine"]
+          version: "2.1.10"
+          filters: *filters
+          post-steps:
+            - check_aws_version:
+                version: "2.1.10"
+      Test overriding existing version of AWS pre-installed
+      - integration-test-install:
+          name: integration-test-install-override-version-<<matrix.executor>>
+          context: [CPE_ORBS_AWS]
+          matrix:
+            alias: test-install-override-version
+            parameters:
+              executor: ["linuxvm", "windows", "arm"]
+          version: "2.1.10"
+          install_dir: "/usr/local/aws-cli"
+          binary_dir: ""
+          override_installed: true
+          filters: *filters
+          post-steps:
+            - check_aws_version:
+                version: "2.1.10"
+      - integration-test-role-arn-setup:
+          name: integration-test-role_arn-config
+          profile_name: "CircleCI-Tester"
+          role_arn: ${ROLE_ARN}
+          context: [CPE_ORBS_AWS]
+      - orb-tools/pack:
+          filters: *release-filters
+      - orb-tools/publish:
+          orb_name: circleci/aws-cli
+          vcs_type: << pipeline.project.type >>
+          pub_type: production
+          enable_pr_comment: true
+          context: orb-publisher
+          requires: [orb-tools/pack, test-install, test-install-version, test-install-override-version, integration-test-web-identity-profile, integration-test-role_arn-config]
+          filters: *release-filters
 executors:
   alpine:
     docker:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -93,70 +93,70 @@ workflows:
   test-deploy:
     jobs:
       - integration-test-install:
-          name: integration-test-web-identity-profile
+          name: integration test web identity profile
           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
           profile_name: "OIDC-User"
           context: [CPE-OIDC]
-          executor: arm
+          executor: docker-base
           post-steps:
             - run:
                 name: Web Identity Test - Logging into ECR
                 command: aws ecr get-login-password --region us-west-2 --profile "OIDC-User" | docker login --username AWS --password-stdin 122211685980.dkr.ecr.us-west-2.amazonaws.com
       # Testing executors that do not AWS pre-installed
-      - integration-test-install:
-          name: integration-test-install-<<matrix.executor>>
-          context: [CPE_ORBS_AWS]
-          matrix:
-            alias: test-install
-            parameters:
-              executor: ["docker-base", "macos", "alpine"]
-          filters: *filters
-          post-steps:
-            - check_aws_version
+      # - integration-test-install:
+      #     name: integration-test-install-<<matrix.executor>>
+      #     context: [CPE_ORBS_AWS]
+      #     matrix:
+      #       alias: test-install
+      #       parameters:
+      #         executor: ["docker-base", "macos", "alpine"]
+      #     filters: *filters
+      #     post-steps:
+      #       - check_aws_version
       # Test installing specific versions on executors without AWS pre-installed
-      - integration-test-install:
-          name: integration-test-install-version-<<matrix.executor>>
-          context: [CPE_ORBS_AWS]
-          matrix:
-            alias: test-install-version
-            parameters:
-              executor: ["docker-base", "macos", "alpine"]
-          version: "2.1.10"
-          filters: *filters
-          post-steps:
-            - check_aws_version:
-                version: "2.1.10"
+      # - integration-test-install:
+      #     name: integration-test-install-version-<<matrix.executor>>
+      #     context: [CPE_ORBS_AWS]
+      #     matrix:
+      #       alias: test-install-version
+      #       parameters:
+      #         executor: ["docker-base", "macos", "alpine"]
+      #     version: "2.1.10"
+      #     filters: *filters
+      #     post-steps:
+      #       - check_aws_version:
+      #           version: "2.1.10"
       # Test overriding existing version of AWS pre-installed
-      - integration-test-install:
-          name: integration-test-install-override-version-<<matrix.executor>>
-          context: [CPE_ORBS_AWS]
-          matrix:
-            alias: test-install-override-version
-            parameters:
-              executor: ["linuxvm", "windows", "arm"]
-          version: "2.1.10"
-          install_dir: "/usr/local/aws-cli"
-          binary_dir: ""
-          override_installed: true
-          filters: *filters
-          post-steps:
-            - check_aws_version:
-                version: "2.1.10"
-      - integration-test-role-arn-setup:
-          name: integration-test-role_arn-config
-          profile_name: "CircleCI-Tester"
-          role_arn: ${ROLE_ARN}
-          context: [CPE_ORBS_AWS]
-      - orb-tools/pack:
-          filters: *release-filters
-      - orb-tools/publish:
-          orb_name: circleci/aws-cli
-          vcs_type: << pipeline.project.type >>
-          pub_type: production
-          enable_pr_comment: true
-          context: orb-publisher
-          requires: [orb-tools/pack, test-install, test-install-version, test-install-override-version, integration-test-web-identity-profile, integration-test-role_arn-config]
-          filters: *release-filters
+      # - integration-test-install:
+      #     name: integration-test-install-override-version-<<matrix.executor>>
+      #     context: [CPE_ORBS_AWS]
+      #     matrix:
+      #       alias: test-install-override-version
+      #       parameters:
+      #         executor: ["linuxvm", "windows", "arm"]
+      #     version: "2.1.10"
+      #     install_dir: "/usr/local/aws-cli"
+      #     binary_dir: ""
+      #     override_installed: true
+      #     filters: *filters
+      #     post-steps:
+      #       - check_aws_version:
+      #           version: "2.1.10"
+      # - integration-test-role-arn-setup:
+      #     name: integration-test-role_arn-config
+      #     profile_name: "CircleCI-Tester"
+      #     role_arn: ${ROLE_ARN}
+      #     context: [CPE_ORBS_AWS]
+      # - orb-tools/pack:
+      #     filters: *release-filters
+      # - orb-tools/publish:
+      #     orb_name: circleci/aws-cli
+      #     vcs_type: << pipeline.project.type >>
+      #     pub_type: production
+      #     enable_pr_comment: true
+      #     context: orb-publisher
+      #     requires: [orb-tools/pack, test-install, test-install-version, test-install-override-version, integration-test-web-identity-profile, integration-test-role_arn-config]
+      #     filters: *release-filters
 executors:
   alpine:
     docker:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -93,7 +93,16 @@ workflows:
   test-deploy:
     jobs:
       - integration-test-install:
-          name: integration test web identity profile
+          name: integration test web identity command with white spaces
+          role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+          context: [CPE-OIDC]
+          executor: docker-base
+          post-steps:
+            - run:
+                name: Web Identity Test - Logging into ECR
+                command: aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin 122211685980.dkr.ecr.us-west-2.amazonaws.com
+      - integration-test-install:
+          name: integration-test-web-identity-with-profile
           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
           profile_name: "OIDC-User"
           context: [CPE-OIDC]
@@ -143,7 +152,7 @@ workflows:
             - check_aws_version:
                 version: "2.1.10"
       - integration-test-role-arn-setup:
-          name: integration-test-role_arn-config
+          name: integration-test-role-arn-config
           profile_name: "CircleCI-Tester"
           role_arn: ${ROLE_ARN}
           context: [CPE_ORBS_AWS]
@@ -155,7 +164,7 @@ workflows:
           pub_type: production
           enable_pr_comment: true
           context: orb-publisher
-          requires: [orb-tools/pack, test-install, test-install-version, test-install-override-version, integration test web identity profile, integration-test-role_arn-config]
+          requires: [orb-tools/pack, test-install, test-install-version, test-install-override-version, integration-test-web-identity-with-profile, integration test web identity command with white spaces,integration-test-role-arn-config]
           filters: *release-filters
 executors:
   alpine:

--- a/src/scripts/assume_role_with_web_identity.sh
+++ b/src/scripts/assume_role_with_web_identity.sh
@@ -1,7 +1,10 @@
-# shellcheck disable=SC2148
+#!/bin/sh
 ORB_EVAL_ROLE_SESSION_NAME=$(circleci env subst "${ORB_EVAL_ROLE_SESSION_NAME}")
 ORB_EVAL_ROLE_ARN=$(circleci env subst "${ORB_EVAL_ROLE_ARN}")
 ORB_EVAL_PROFILE_NAME=$(circleci env subst "$ORB_EVAL_PROFILE_NAME")
+
+# Replaces white spaces role session name with dashes
+ORB_EVAL_ROLE_SESSION_NAME=$(echo "${ORB_EVAL_ROLE_SESSION_NAME}" | tr ' ' '-')
 
 if [ -z "${ORB_EVAL_ROLE_SESSION_NAME}" ]; then
     echo "Role session name is required"

--- a/src/scripts/role_arn_setup.sh
+++ b/src/scripts/role_arn_setup.sh
@@ -1,7 +1,8 @@
-# shellcheck disable=SC2148
+#!/bin/sh
 ORB_EVAL_ROLE_ARN=$(circleci env subst "${ORB_EVAL_ROLE_ARN}")
 ORB_EVAL_PROFILE_NAME=$(circleci env subst "${ORB_EVAL_PROFILE_NAME}")
 ORB_EVAL_SOURCE_PROFILE=$(circleci env subst "${ORB_EVAL_SOURCE_PROFILE}")
+
 if [ ! -f "${HOME}/.aws/credentials" ]; then
     echo "Credentials not found. Run setup command before role-arn-setup."
     exit 1


### PR DESCRIPTION
Currently, job name containing white spaces is valid in CircleCI. However, the `assume-role-with-web-identity` command uses the job name as the default value for the `role-session-name` parameter that gets passed to the `aws cli`. 

The issue is that the `aws cli` command does not accept a `role-session-name` contain white spaces and throws this error: 

`Member must satisfy regular expression pattern: [\w+=,.@-]*`

This `PR` implements a fix to check and see if the job name contains  white spaces. It it does, the spaces are replaces by `-`.