### PR TITLE
fix: nounset shell

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -106,7 +106,7 @@ workflows:
           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
           profile_name: "OIDC-User"
           context: [CPE-OIDC]
-          executor: docker-base
+          executor: arm
           post-steps:
             - run:
                 name: Web Identity Test - Logging into ECR

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -97,71 +97,72 @@ workflows:
           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
           profile_name: "OIDC-User"
           context: [CPE-OIDC]
-          executor: arm
+          executor: docker-base
           post-steps:
             - run:
                 name: Web Identity Test - Logging into ECR
                 command: aws ecr get-login-password --region us-west-2 --profile "OIDC-User" | docker login --username AWS --password-stdin 122211685980.dkr.ecr.us-west-2.amazonaws.com
-      # Testing executors that do not AWS pre-installed
-      - integration-test-install:
-          name: integration-test-install-<<matrix.executor>>
-          context: [CPE_ORBS_AWS]
-          matrix:
-            alias: test-install
-            parameters:
-              executor: ["docker-base", "macos", "alpine"]
-          filters: *filters
-          post-steps:
-            - check_aws_version
-      # Test installing specific versions on executors without AWS pre-installed
-      - integration-test-install:
-          name: integration-test-install-version-<<matrix.executor>>
-          context: [CPE_ORBS_AWS]
-          matrix:
-            alias: test-install-version
-            parameters:
-              executor: ["docker-base", "macos", "alpine"]
-          version: "2.1.10"
-          filters: *filters
-          post-steps:
-            - check_aws_version:
-                version: "2.1.10"
-      # Test overriding existing version of AWS pre-installed
-      - integration-test-install:
-          name: integration-test-install-override-version-<<matrix.executor>>
-          context: [CPE_ORBS_AWS]
-          matrix:
-            alias: test-install-override-version
-            parameters:
-              executor: ["linuxvm", "windows", "arm"]
-          version: "2.1.10"
-          install_dir: "/usr/local/aws-cli"
-          binary_dir: ""
-          override_installed: true
-          filters: *filters
-          post-steps:
-            - check_aws_version:
-                version: "2.1.10"
-      - integration-test-role-arn-setup:
-          name: integration-test-role_arn-config
-          profile_name: "CircleCI-Tester"
-          role_arn: ${ROLE_ARN}
-          context: [CPE_ORBS_AWS]
-      - orb-tools/pack:
-          filters: *release-filters
-      - orb-tools/publish:
-          orb_name: circleci/aws-cli
-          vcs_type: << pipeline.project.type >>
-          pub_type: production
-          enable_pr_comment: true
-          context: orb-publisher
-          requires: [orb-tools/pack, test-install, test-install-version, test-install-override-version, integration-test-web-identity-profile, integration-test-role_arn-config]
-          filters: *release-filters
+      # # Testing executors that do not AWS pre-installed
+      # - integration-test-install:
+      #     name: integration-test-install-<<matrix.executor>>
+      #     context: [CPE_ORBS_AWS]
+      #     matrix:
+      #       alias: test-install
+      #       parameters:
+      #         executor: ["docker-base", "macos", "alpine"]
+      #     filters: *filters
+      #     post-steps:
+      #       - check_aws_version
+      # # Test installing specific versions on executors without AWS pre-installed
+      # - integration-test-install:
+      #     name: integration-test-install-version-<<matrix.executor>>
+      #     context: [CPE_ORBS_AWS]
+      #     matrix:
+      #       alias: test-install-version
+      #       parameters:
+      #         executor: ["docker-base", "macos", "alpine"]
+      #     version: "2.1.10"
+      #     filters: *filters
+      #     post-steps:
+      #       - check_aws_version:
+      #           version: "2.1.10"
+      # # Test overriding existing version of AWS pre-installed
+      # - integration-test-install:
+      #     name: integration-test-install-override-version-<<matrix.executor>>
+      #     context: [CPE_ORBS_AWS]
+      #     matrix:
+      #       alias: test-install-override-version
+      #       parameters:
+      #         executor: ["linuxvm", "windows", "arm"]
+      #     version: "2.1.10"
+      #     install_dir: "/usr/local/aws-cli"
+      #     binary_dir: ""
+      #     override_installed: true
+      #     filters: *filters
+      #     post-steps:
+      #       - check_aws_version:
+      #           version: "2.1.10"
+      # - integration-test-role-arn-setup:
+      #     name: integration-test-role_arn-config
+      #     profile_name: "CircleCI-Tester"
+      #     role_arn: ${ROLE_ARN}
+      #     context: [CPE_ORBS_AWS]
+      # - orb-tools/pack:
+      #     filters: *release-filters
+      # - orb-tools/publish:
+      #     orb_name: circleci/aws-cli
+      #     vcs_type: << pipeline.project.type >>
+      #     pub_type: production
+      #     enable_pr_comment: true
+      #     context: orb-publisher
+      #     requires: [orb-tools/pack, test-install, test-install-version, test-install-override-version, integration-test-web-identity-profile, integration-test-role_arn-config]
+      #     filters: *release-filters
 executors:
   alpine:
     docker:
       - image: alpine:latest
   docker-base:
+    shell: /bin/bash -o nounset
     docker:
       - image: cimg/base:stable
   macos:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -97,7 +97,7 @@ workflows:
           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
           profile_name: "OIDC-User"
           context: [CPE-OIDC]
-          executor: docker-base
+          executor: arm
           post-steps:
             - run:
                 name: Web Identity Test - Logging into ECR

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -102,66 +102,69 @@ workflows:
             - run:
                 name: Web Identity Test - Logging into ECR
                 command: aws ecr get-login-password --region us-west-2 --profile "OIDC-User" | docker login --username AWS --password-stdin 122211685980.dkr.ecr.us-west-2.amazonaws.com
-      # # Testing executors that do not AWS pre-installed
-      # - integration-test-install:
-      #     name: integration-test-install-<<matrix.executor>>
-      #     context: [CPE_ORBS_AWS]
-      #     matrix:
-      #       alias: test-install
-      #       parameters:
-      #         executor: ["docker-base", "macos", "alpine"]
-      #     filters: *filters
-      #     post-steps:
-      #       - check_aws_version
-      # # Test installing specific versions on executors without AWS pre-installed
-      # - integration-test-install:
-      #     name: integration-test-install-version-<<matrix.executor>>
-      #     context: [CPE_ORBS_AWS]
-      #     matrix:
-      #       alias: test-install-version
-      #       parameters:
-      #         executor: ["docker-base", "macos", "alpine"]
-      #     version: "2.1.10"
-      #     filters: *filters
-      #     post-steps:
-      #       - check_aws_version:
-      #           version: "2.1.10"
-      # # Test overriding existing version of AWS pre-installed
-      # - integration-test-install:
-      #     name: integration-test-install-override-version-<<matrix.executor>>
-      #     context: [CPE_ORBS_AWS]
-      #     matrix:
-      #       alias: test-install-override-version
-      #       parameters:
-      #         executor: ["linuxvm", "windows", "arm"]
-      #     version: "2.1.10"
-      #     install_dir: "/usr/local/aws-cli"
-      #     binary_dir: ""
-      #     override_installed: true
-      #     filters: *filters
-      #     post-steps:
-      #       - check_aws_version:
-      #           version: "2.1.10"
-      # - integration-test-role-arn-setup:
-      #     name: integration-test-role_arn-config
-      #     profile_name: "CircleCI-Tester"
-      #     role_arn: ${ROLE_ARN}
-      #     context: [CPE_ORBS_AWS]
-      # - orb-tools/pack:
-      #     filters: *release-filters
-      # - orb-tools/publish:
-      #     orb_name: circleci/aws-cli
-      #     vcs_type: << pipeline.project.type >>
-      #     pub_type: production
-      #     enable_pr_comment: true
-      #     context: orb-publisher
-      #     requires: [orb-tools/pack, test-install, test-install-version, test-install-override-version, integration-test-web-identity-profile, integration-test-role_arn-config]
-      #     filters: *release-filters
+      # Testing executors that do not AWS pre-installed
+      - integration-test-install:
+          name: integration-test-install-<<matrix.executor>>
+          context: [CPE_ORBS_AWS]
+          matrix:
+            alias: test-install
+            parameters:
+              executor: ["docker-base", "macos", "alpine", "docker-nounset-shell" ]
+          filters: *filters
+          post-steps:
+            - check_aws_version
+      # Test installing specific versions on executors without AWS pre-installed
+      - integration-test-install:
+          name: integration-test-install-version-<<matrix.executor>>
+          context: [CPE_ORBS_AWS]
+          matrix:
+            alias: test-install-version
+            parameters:
+              executor: ["docker-base", "macos", "alpine", "docker-nounset-shell" ]
+          version: "2.1.10"
+          filters: *filters
+          post-steps:
+            - check_aws_version:
+                version: "2.1.10"
+      # Test overriding existing version of AWS pre-installed
+      - integration-test-install:
+          name: integration-test-install-override-version-<<matrix.executor>>
+          context: [CPE_ORBS_AWS]
+          matrix:
+            alias: test-install-override-version
+            parameters:
+              executor: ["linuxvm", "windows", "arm"]
+          version: "2.1.10"
+          install_dir: "/usr/local/aws-cli"
+          binary_dir: ""
+          override_installed: true
+          filters: *filters
+          post-steps:
+            - check_aws_version:
+                version: "2.1.10"
+      - integration-test-role-arn-setup:
+          name: integration-test-role_arn-config
+          profile_name: "CircleCI-Tester"
+          role_arn: ${ROLE_ARN}
+          context: [CPE_ORBS_AWS]
+      - orb-tools/pack:
+          filters: *release-filters
+      - orb-tools/publish:
+          orb_name: circleci/aws-cli
+          vcs_type: << pipeline.project.type >>
+          pub_type: production
+          enable_pr_comment: true
+          context: orb-publisher
+          requires: [orb-tools/pack, test-install, test-install-version, test-install-override-version, integration-test-web-identity-profile, integration-test-role_arn-config]
+          filters: *release-filters
 executors:
   alpine:
     docker:
       - image: alpine:latest
   docker-base:
+    docker:
+      - image: cimg/base:stable
+  docker-nounset-shell:
     shell: /bin/bash -o nounset
     docker:
       - image: cimg/base:stable

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -106,7 +106,7 @@ workflows:
           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
           profile_name: "OIDC-User"
           context: [CPE-OIDC]
-          executor: arm
+          executor: docker-base
           post-steps:
             - run:
                 name: Web Identity Test - Logging into ECR

--- a/src/commands/assume_role_with_web_identity.yml
+++ b/src/commands/assume_role_with_web_identity.yml
@@ -30,8 +30,8 @@ steps:
   - run:
       name: Generate shortlived AWS Keys using CircleCI OIDC token.
       environment:
-        ORB_EVAL_ROLE_ARN: <<parameters.role_arn>>
-        ORB_EVAL_ROLE_SESSION_NAME: <<parameters.role_session_name>>
-        ORB_VAL_SESSION_DURATION: <<parameters.session_duration>>
-        ORB_EVAL_PROFILE_NAME: <<parameters.profile_name>>
+        ORB_STR_ROLE_ARN: <<parameters.role_arn>>
+        ORB_STR_ROLE_SESSION_NAME: <<parameters.role_session_name>>
+        ORB_INT_SESSION_DURATION: <<parameters.session_duration>>
+        ORB_STR_PROFILE_NAME: <<parameters.profile_name>>
       command: <<include(scripts/assume_role_with_web_identity.sh)>>

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -30,9 +30,9 @@ steps:
   - run:
       name: Install AWS CLI - <<parameters.version>>
       environment:
-        ORB_VAL_AWS_CLI_VERSION: <<parameters.version>>
-        ORB_VAL_DISABLE_PAGER: <<parameters.disable_aws_pager>>
-        ORB_VAL_OVERRIDE: <<parameters.override_installed>>
-        ORB_VAL_INSTALL_DIR: <<parameters.install_dir>>
-        ORB_VAL_BINARY_DIR: <<parameters.binary_dir>>
+        ORB_STR_AWS_CLI_VERSION: <<parameters.version>>
+        ORB_BOOL_DISABLE_PAGER: <<parameters.disable_aws_pager>>
+        ORB_BOOL_OVERRIDE: <<parameters.override_installed>>
+        ORB_EVAL_INSTALL_DIR: <<parameters.install_dir>>
+        ORB_EVAL_BINARY_DIR: <<parameters.binary_dir>>
       command: <<include(scripts/install.sh)>>

--- a/src/commands/role_arn_setup.yml
+++ b/src/commands/role_arn_setup.yml
@@ -18,7 +18,7 @@ steps:
   - run:
       name: Configure role arn for profile <<parameters.profile_name>>
       environment:
-        ORB_EVAL_PROFILE_NAME: <<parameters.profile_name>>
+        ORB_STR_PROFILE_NAME: <<parameters.profile_name>>
         ORB_EVAL_SOURCE_PROFILE: <<parameters.source_profile>>
-        ORB_EVAL_ROLE_ARN: <<parameters.role_arn>>
+        ORB_STR_ROLE_ARN: <<parameters.role_arn>>
       command: <<include(scripts/role_arn_setup.sh)>>

--- a/src/commands/role_arn_setup.yml
+++ b/src/commands/role_arn_setup.yml
@@ -19,6 +19,6 @@ steps:
       name: Configure role arn for profile <<parameters.profile_name>>
       environment:
         ORB_STR_PROFILE_NAME: <<parameters.profile_name>>
-        ORB_EVAL_SOURCE_PROFILE: <<parameters.source_profile>>
+        ORB_STR_SOURCE_PROFILE: <<parameters.source_profile>>
         ORB_STR_ROLE_ARN: <<parameters.role_arn>>
       command: <<include(scripts/role_arn_setup.sh)>>

--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -113,8 +113,8 @@ steps:
       environment:
         ORB_ENV_ACCESS_KEY_ID: <<parameters.aws_access_key_id>>
         ORB_ENV_SECRET_ACCESS_KEY: <<parameters.aws_secret_access_key>>
-        ORB_EVAL_PROFILE_NAME: <<parameters.profile_name>>
-        ORB_VAL_CONFIG_DEFAULT_REGION: <<parameters.configure_default_region>>
-        ORB_VAL_CONFIG_PROFILE_REGION: <<parameters.configure_profile_region>>
-        ORB_EVAL_AWS_CLI_REGION: <<parameters.region>>
+        ORB_STR_PROFILE_NAME: <<parameters.profile_name>>
+        ORB_BOOL_CONFIG_DEFAULT_REGION: <<parameters.configure_default_region>>
+        ORB_BOOL_CONFIG_PROFILE_REGION: <<parameters.configure_profile_region>>
+        ORB_STR_REGION: <<parameters.region>>
       command: <<include(scripts/configure.sh)>>

--- a/src/scripts/assume_role_with_web_identity.sh
+++ b/src/scripts/assume_role_with_web_identity.sh
@@ -1,9 +1,9 @@
 # shellcheck disable=SC2148
-ORB_EVAL_ROLE_SESSION_NAME=$(circleci env subst "${ORB_EVAL_ROLE_SESSION_NAME}")
-ORB_EVAL_ROLE_ARN=$(circleci env subst "${ORB_EVAL_ROLE_ARN}")
-ORB_EVAL_PROFILE_NAME=$(circleci env subst "$ORB_EVAL_PROFILE_NAME")
+ORB_STR_ROLE_SESSION_NAME=$(circleci env subst "${ORB_STR_ROLE_SESSION_NAME}")
+ORB_STR_ROLE_ARN=$(circleci env subst "${ORB_STR_ROLE_ARN}")
+ORB_STR_PROFILE_NAME=$(circleci env subst "$ORB_STR_PROFILE_NAME")
 
-if [ -z "${ORB_EVAL_ROLE_SESSION_NAME}" ]; then
+if [ -z "${ORB_STR_ROLE_SESSION_NAME}" ]; then
     echo "Role session name is required"
     exit 1
 fi
@@ -20,10 +20,10 @@ fi
 
 read -r AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN <<EOF
 $(aws sts assume-role-with-web-identity \
---role-arn "${ORB_EVAL_ROLE_ARN}" \
---role-session-name "${ORB_EVAL_ROLE_SESSION_NAME}" \
+--role-arn "${ORB_STR_ROLE_ARN}" \
+--role-session-name "${ORB_STR_ROLE_SESSION_NAME}" \
 --web-identity-token "${CIRCLE_OIDC_TOKEN_V2}" \
---duration-seconds "${ORB_VAL_SESSION_DURATION}" \
+--duration-seconds "${ORB_INT_SESSION_DURATION}" \
 --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' \
 --output text)
 EOF

--- a/src/scripts/assume_role_with_web_identity.sh
+++ b/src/scripts/assume_role_with_web_identity.sh
@@ -3,7 +3,17 @@ ORB_STR_ROLE_SESSION_NAME="$(circleci env subst "${ORB_STR_ROLE_SESSION_NAME}")"
 ORB_STR_ROLE_ARN="$(circleci env subst "${ORB_STR_ROLE_ARN}")"
 ORB_STR_PROFILE_NAME="$(circleci env subst "$ORB_STR_PROFILE_NAME")"
 
+<<<<<<< HEAD
 if [ -z "${ORB_STR_ROLE_SESSION_NAME}" ]; then
+=======
+# Replaces white spaces in role session name with dashes
+ORB_EVAL_ROLE_SESSION_NAME=$(echo "${ORB_EVAL_ROLE_SESSION_NAME}" | tr ' ' '-')
+
+# Replaces white spaces role session name with dashes
+ORB_EVAL_ROLE_SESSION_NAME=$(echo "${ORB_EVAL_ROLE_SESSION_NAME}" | tr ' ' '-')
+
+if [ -z "${ORB_EVAL_ROLE_SESSION_NAME}" ]; then
+>>>>>>> cd4235a (fix: unbound variable in config command)
     echo "Role session name is required"
     exit 1
 fi

--- a/src/scripts/assume_role_with_web_identity.sh
+++ b/src/scripts/assume_role_with_web_identity.sh
@@ -3,6 +3,7 @@ ORB_STR_ROLE_SESSION_NAME=$(circleci env subst "${ORB_STR_ROLE_SESSION_NAME}")
 ORB_STR_ROLE_ARN=$(circleci env subst "${ORB_STR_ROLE_ARN}")
 ORB_STR_PROFILE_NAME=$(circleci env subst "$ORB_STR_PROFILE_NAME")
 
+
 if [ -z "${ORB_STR_ROLE_SESSION_NAME}" ]; then
     echo "Role session name is required"
     exit 1

--- a/src/scripts/assume_role_with_web_identity.sh
+++ b/src/scripts/assume_role_with_web_identity.sh
@@ -1,11 +1,12 @@
-# shellcheck disable=SC2148
+#!/bin/sh
 ORB_STR_ROLE_SESSION_NAME="$(circleci env subst "${ORB_STR_ROLE_SESSION_NAME}")"
 ORB_STR_ROLE_ARN="$(circleci env subst "${ORB_STR_ROLE_ARN}")"
 ORB_STR_PROFILE_NAME="$(circleci env subst "$ORB_STR_PROFILE_NAME")"
 
+# Replaces white spaces in role session name with dashes
+ORB_EVAL_ROLE_SESSION_NAME=$(echo "${ORB_EVAL_ROLE_SESSION_NAME}" | tr ' ' '-')
 
 if [ -z "${ORB_STR_ROLE_SESSION_NAME}" ]; then
-
     echo "Role session name is required"
     exit 1
 fi

--- a/src/scripts/assume_role_with_web_identity.sh
+++ b/src/scripts/assume_role_with_web_identity.sh
@@ -3,9 +3,6 @@ ORB_STR_ROLE_SESSION_NAME="$(circleci env subst "${ORB_STR_ROLE_SESSION_NAME}")"
 ORB_STR_ROLE_ARN="$(circleci env subst "${ORB_STR_ROLE_ARN}")"
 ORB_STR_PROFILE_NAME="$(circleci env subst "$ORB_STR_PROFILE_NAME")"
 
-# Replaces white spaces in role session name with dashes
-ORB_EVAL_ROLE_SESSION_NAME=$(echo "${ORB_EVAL_ROLE_SESSION_NAME}" | tr ' ' '-')
-
 if [ -z "${ORB_STR_ROLE_SESSION_NAME}" ]; then
     echo "Role session name is required"
     exit 1

--- a/src/scripts/assume_role_with_web_identity.sh
+++ b/src/scripts/assume_role_with_web_identity.sh
@@ -3,6 +3,9 @@ ORB_STR_ROLE_SESSION_NAME="$(circleci env subst "${ORB_STR_ROLE_SESSION_NAME}")"
 ORB_STR_ROLE_ARN="$(circleci env subst "${ORB_STR_ROLE_ARN}")"
 ORB_STR_PROFILE_NAME="$(circleci env subst "$ORB_STR_PROFILE_NAME")"
 
+# Replaces white spaces in role session name with dashes
+ORB_STR_ROLE_SESSION_NAME=$(echo "${ORB_STR_ROLE_SESSION_NAME}" | tr ' ' '-')
+
 if [ -z "${ORB_STR_ROLE_SESSION_NAME}" ]; then
     echo "Role session name is required"
     exit 1

--- a/src/scripts/assume_role_with_web_identity.sh
+++ b/src/scripts/assume_role_with_web_identity.sh
@@ -3,17 +3,7 @@ ORB_STR_ROLE_SESSION_NAME="$(circleci env subst "${ORB_STR_ROLE_SESSION_NAME}")"
 ORB_STR_ROLE_ARN="$(circleci env subst "${ORB_STR_ROLE_ARN}")"
 ORB_STR_PROFILE_NAME="$(circleci env subst "$ORB_STR_PROFILE_NAME")"
 
-<<<<<<< HEAD
 if [ -z "${ORB_STR_ROLE_SESSION_NAME}" ]; then
-=======
-# Replaces white spaces in role session name with dashes
-ORB_EVAL_ROLE_SESSION_NAME=$(echo "${ORB_EVAL_ROLE_SESSION_NAME}" | tr ' ' '-')
-
-# Replaces white spaces role session name with dashes
-ORB_EVAL_ROLE_SESSION_NAME=$(echo "${ORB_EVAL_ROLE_SESSION_NAME}" | tr ' ' '-')
-
-if [ -z "${ORB_EVAL_ROLE_SESSION_NAME}" ]; then
->>>>>>> cd4235a (fix: unbound variable in config command)
     echo "Role session name is required"
     exit 1
 fi

--- a/src/scripts/assume_role_with_web_identity.sh
+++ b/src/scripts/assume_role_with_web_identity.sh
@@ -1,7 +1,7 @@
 # shellcheck disable=SC2148
-ORB_STR_ROLE_SESSION_NAME=$(circleci env subst "${ORB_STR_ROLE_SESSION_NAME}")
-ORB_STR_ROLE_ARN=$(circleci env subst "${ORB_STR_ROLE_ARN}")
-ORB_STR_PROFILE_NAME=$(circleci env subst "$ORB_STR_PROFILE_NAME")
+ORB_STR_ROLE_SESSION_NAME="$(circleci env subst "${ORB_STR_ROLE_SESSION_NAME}")"
+ORB_STR_ROLE_ARN="$(circleci env subst "${ORB_STR_ROLE_ARN}")"
+ORB_STR_PROFILE_NAME="$(circleci env subst "$ORB_STR_PROFILE_NAME")"
 
 
 if [ -z "${ORB_STR_ROLE_SESSION_NAME}" ]; then

--- a/src/scripts/configure.sh
+++ b/src/scripts/configure.sh
@@ -7,8 +7,8 @@ fi
 
 ORB_ENV_ACCESS_KEY_ID=$(circleci env subst "\$$ORB_ENV_ACCESS_KEY_ID")
 ORB_ENV_SECRET_ACCESS_KEY=$(circleci env subst "\$$ORB_ENV_SECRET_ACCESS_KEY")
-ORB_EVAL_AWS_CLI_REGION=$(circleci env subst "\$$ORB_EVAL_AWS_CLI_REGION")
-ORB_EVAL_PROFILE_NAME=$(circleci env subst "$ORB_EVAL_PROFILE_NAME")
+ORB_STR_REGION=$(circleci env subst "\$$ORB_STR_REGION")
+ORB_STR_PROFILE_NAME=$(circleci env subst "$ORB_STR_PROFILE_NAME")
 
 if [ -z "$ORB_ENV_ACCESS_KEY_ID" ] || [ -z "${ORB_ENV_SECRET_ACCESS_KEY}" ]; then 
     echo "Cannot configure profile. AWS access key id and AWS secret access key must be provided."
@@ -17,24 +17,24 @@ fi
 
 aws configure set aws_access_key_id \
     "$ORB_ENV_ACCESS_KEY_ID" \
-    --profile "$ORB_EVAL_PROFILE_NAME"
+    --profile "$ORB_STR_PROFILE_NAME"
 
 aws configure set aws_secret_access_key \
     "$ORB_ENV_SECRET_ACCESS_KEY" \
-    --profile "$ORB_EVAL_PROFILE_NAME"
+    --profile "$ORB_STR_PROFILE_NAME"
 
 if [ -n "${AWS_SESSION_TOKEN}" ]; then
     aws configure set aws_session_token \
         "${AWS_SESSION_TOKEN}" \
-        --profile "$ORB_EVAL_PROFILE_NAME"
+        --profile "$ORB_STR_PROFILE_NAME"
 fi
 
-if [ "$ORB_VAL_CONFIG_DEFAULT_REGION" = "1" ]; then
-    aws configure set default.region "$ORB_EVAL_AWS_CLI_REGION" \
-        --profile "$ORB_EVAL_PROFILE_NAME"
+if [ "$ORB_BOOL_CONFIG_DEFAULT_REGION" = "1" ]; then
+    aws configure set default.region "$ORB_STR_REGION" \
+        --profile "$ORB_STR_PROFILE_NAME"
 fi
 
-if [ "$ORB_VAL_CONFIG_PROFILE_REGION" = "1" ]; then
-    aws configure set region "$ORB_EVAL_AWS_CLI_REGION" \
-        --profile "$ORB_EVAL_PROFILE_NAME"
+if [ "$ORB_BOOL_CONFIG_PROFILE_REGION" = "1" ]; then
+    aws configure set region "$ORB_STR_REGION" \
+        --profile "$ORB_STR_PROFILE_NAME"
 fi

--- a/src/scripts/configure.sh
+++ b/src/scripts/configure.sh
@@ -7,6 +7,7 @@ fi
 
 ORB_ENV_ACCESS_KEY_ID=$(circleci env subst "\$$ORB_ENV_ACCESS_KEY_ID")
 ORB_ENV_SECRET_ACCESS_KEY=$(circleci env subst "\$$ORB_ENV_SECRET_ACCESS_KEY")
+AWS_SESSION_TOKEN=$(circleci env subst "$AWS_SESSION_TOKEN")
 ORB_STR_REGION=$(circleci env subst "\$$ORB_STR_REGION")
 ORB_STR_PROFILE_NAME=$(circleci env subst "$ORB_STR_PROFILE_NAME")
 

--- a/src/scripts/configure.sh
+++ b/src/scripts/configure.sh
@@ -7,9 +7,9 @@ fi
 
 ORB_ENV_ACCESS_KEY_ID=$(circleci env subst "\$$ORB_ENV_ACCESS_KEY_ID")
 ORB_ENV_SECRET_ACCESS_KEY=$(circleci env subst "\$$ORB_ENV_SECRET_ACCESS_KEY")
-AWS_SESSION_TOKEN=$(circleci env subst "$AWS_SESSION_TOKEN")
-ORB_STR_REGION=$(circleci env subst "\$$ORB_STR_REGION")
-ORB_STR_PROFILE_NAME=$(circleci env subst "$ORB_STR_PROFILE_NAME")
+AWS_SESSION_TOKEN="$(circleci env subst "$AWS_SESSION_TOKEN")"
+ORB_STR_REGION="$(circleci env subst "\$$ORB_STR_REGION")"
+ORB_STR_PROFILE_NAME="$(circleci env subst "$ORB_STR_PROFILE_NAME")"
 
 if [ -z "$ORB_ENV_ACCESS_KEY_ID" ] || [ -z "${ORB_ENV_SECRET_ACCESS_KEY}" ]; then 
     echo "Cannot configure profile. AWS access key id and AWS secret access key must be provided."

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -13,7 +13,6 @@ else
 fi
 
 Install_AWS_CLI() {
-    # local version="$1"
     echo "Installing AWS CLI v2"
     cd /tmp || exit
     # Platform check

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -1,6 +1,8 @@
 # shellcheck disable=SC2148
 
+set -x
 ORB_STR_AWS_CLI_VERSION="$(echo "${ORB_STR_AWS_CLI_VERSION}" | circleci env subst)"
+set +x
 ORB_EVAL_INSTALL_DIR="$(eval echo "${ORB_EVAL_INSTALL_DIR}")"
 ORB_EVAL_BINARY_DIR="$(eval echo "${ORB_EVAL_BINARY_DIR}")"
 
@@ -11,7 +13,7 @@ else
 fi
 
 Install_AWS_CLI() {
-    local version="$1"
+    # local version="$1"
     echo "Installing AWS CLI v2"
     cd /tmp || exit
     # Platform check
@@ -34,7 +36,7 @@ Install_AWS_CLI() {
     # Install per platform
     case $SYS_ENV_PLATFORM in
     linux_x86)
-        curl -sSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64$version.zip" -o "awscliv2.zip"
+        curl -sSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64$1.zip" -o "awscliv2.zip"
         unzip -q -o awscliv2.zip
         $SUDO ./aws/install -i "${ORB_EVAL_INSTALL_DIR}" -b "${ORB_EVAL_BINARY_DIR}"
         rm -r awscliv2.zip ./aws
@@ -44,9 +46,9 @@ Install_AWS_CLI() {
             echo "Chocolatey is required to uninstall AWS"
             exit 1
         fi
-        choco install awscli --version="$version"
-        echo "$version"
-        if echo "$version" | grep "2."; then
+        choco install awscli --version="$1"
+        echo "$1"
+        if echo "$1" | grep "2."; then
             echo "export PATH=\"\${PATH}:/c/Program Files/Amazon/AWSCLIV2\"" >> "$BASH_ENV"
 
         else
@@ -54,12 +56,12 @@ Install_AWS_CLI() {
         fi
         ;;
     macos)
-        curl -sSL "https://awscli.amazonaws.com/AWSCLIV2$version.pkg" -o "AWSCLIV2.pkg"
+        curl -sSL "https://awscli.amazonaws.com/AWSCLIV2$1.pkg" -o "AWSCLIV2.pkg"
         $SUDO installer -pkg AWSCLIV2.pkg -target /
         rm AWSCLIV2.pkg
         ;;
     linux_arm)
-        curl -sSL "https://awscli.amazonaws.com/awscli-exe-linux-aarch64$version.zip" -o "awscliv2.zip"
+        curl -sSL "https://awscli.amazonaws.com/awscli-exe-linux-aarch64$1.zip" -o "awscliv2.zip"
         unzip -q -o awscliv2.zip
         $SUDO ./aws/install -i "${ORB_EVAL_INSTALL_DIR}" -b "${ORB_EVAL_BINARY_DIR}"
         rm -r awscliv2.zip ./aws
@@ -80,9 +82,9 @@ Install_AWS_CLI() {
             glibc-i18n-2.34-r0.apk
 
         /usr/glibc-compat/bin/localedef -i en_US -f UTF-8 en_US.UTF-8
-        curl -sSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64$version.zip" -o "awscliv2.zip"
+        curl -sSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64$1.zip" -o "awscliv2.zip"
 
-        echo "https://awscli.amazonaws.com/awscli-exe-linux-x86_64$version.zip"
+        echo "https://awscli.amazonaws.com/awscli-exe-linux-x86_64$1.zip"
         unzip awscliv2.zip
         aws/install
         rm -r awscliv2.zip ./aws
@@ -130,7 +132,7 @@ Uninstall_AWS_CLI() {
 
 if [ ! "$(command -v aws)" ]; then
     if [ "$ORB_STR_AWS_CLI_VERSION" = "latest" ]; then
-        Install_AWS_CLI
+        Install_AWS_CLI ""
     else
         if uname -a | grep "x86_64 Msys"; then
             Install_AWS_CLI "${ORB_STR_AWS_CLI_VERSION}"

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -139,7 +139,7 @@ if [ ! "$(command -v aws)" ]; then
             Install_AWS_CLI "-${ORB_STR_AWS_CLI_VERSION}"
         fi
     fi
-elif [ "$ORB_BOOL_OVERRIDE" = 1 ]; then
+elif [ "$ORB_BOOL_OVERRIDE" -eq 1 ]; then
     Uninstall_AWS_CLI
     if uname -a | grep "x86_64 Msys"; then
         Install_AWS_CLI "${ORB_STR_AWS_CLI_VERSION}"

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -95,7 +95,7 @@ Install_AWS_CLI() {
         ;;
     esac
     # Toggle AWS Pager
-    if [ "$ORB_BOOL_DISABLE_PAGER" = 1 ]; then
+    if [ "$ORB_BOOL_DISABLE_PAGER" -eq 1 ]; then
         if [ -z "${AWS_PAGER+x}" ]; then
             echo 'export AWS_PAGER=""' >>"$BASH_ENV"
             echo "AWS_PAGER is being set to the empty string to disable all output paging for AWS CLI commands."

--- a/src/scripts/role_arn_setup.sh
+++ b/src/scripts/role_arn_setup.sh
@@ -1,6 +1,6 @@
 # shellcheck disable=SC2148
-ORB_STR_ROLE_ARN=$(circleci env subst "${ORB_STR_ROLE_ARN}")
-ORB_STR_PROFILE_NAME=$(circleci env subst "${ORB_STR_PROFILE_NAME}")
+ORB_STR_ROLE_ARN="$(circleci env subst "${ORB_STR_ROLE_ARN}")"
+ORB_STR_PROFILE_NAME="$(circleci env subst "${ORB_STR_PROFILE_NAME}")"
 ORB_EVAL_SOURCE_PROFILE=$(circleci env subst "${ORB_EVAL_SOURCE_PROFILE}")
 if [ ! -f "${HOME}/.aws/credentials" ]; then
     echo "Credentials not found. Run setup command before role-arn-setup."

--- a/src/scripts/role_arn_setup.sh
+++ b/src/scripts/role_arn_setup.sh
@@ -1,7 +1,7 @@
-# shellcheck disable=SC2148
+#!/bin/sh
 ORB_STR_ROLE_ARN="$(circleci env subst "${ORB_STR_ROLE_ARN}")"
 ORB_STR_PROFILE_NAME="$(circleci env subst "${ORB_STR_PROFILE_NAME}")"
-ORB_EVAL_SOURCE_PROFILE=$(circleci env subst "${ORB_EVAL_SOURCE_PROFILE}")
+ORB_STR_SOURCE_PROFILE=$(circleci env subst "${ORB_STR_SOURCE_PROFILE}")
 
 if [ ! -f "${HOME}/.aws/credentials" ]; then
     echo "Credentials not found. Run setup command before role-arn-setup."
@@ -9,4 +9,4 @@ if [ ! -f "${HOME}/.aws/credentials" ]; then
 fi
 
 aws configure set profile."${ORB_STR_PROFILE_NAME}".role_arn "${ORB_STR_ROLE_ARN}"
-aws configure set profile."${ORB_STR_PROFILE_NAME}".source_profile "${ORB_EVAL_SOURCE_PROFILE}"
+aws configure set profile."${ORB_STR_PROFILE_NAME}".source_profile "${ORB_STR_SOURCE_PROFILE}"

--- a/src/scripts/role_arn_setup.sh
+++ b/src/scripts/role_arn_setup.sh
@@ -3,6 +3,7 @@ ORB_STR_ROLE_ARN="$(circleci env subst "${ORB_STR_ROLE_ARN}")"
 ORB_STR_PROFILE_NAME="$(circleci env subst "${ORB_STR_PROFILE_NAME}")"
 ORB_STR_SOURCE_PROFILE="$(circleci env subst "${ORB_STR_SOURCE_PROFILE}")"
 
+
 if [ ! -f "${HOME}/.aws/credentials" ]; then
     echo "Credentials not found. Run setup command before role-arn-setup."
     exit 1

--- a/src/scripts/role_arn_setup.sh
+++ b/src/scripts/role_arn_setup.sh
@@ -1,11 +1,11 @@
 # shellcheck disable=SC2148
-ORB_EVAL_ROLE_ARN=$(circleci env subst "${ORB_EVAL_ROLE_ARN}")
-ORB_EVAL_PROFILE_NAME=$(circleci env subst "${ORB_EVAL_PROFILE_NAME}")
+ORB_STR_ROLE_ARN=$(circleci env subst "${ORB_STR_ROLE_ARN}")
+ORB_STR_PROFILE_NAME=$(circleci env subst "${ORB_STR_PROFILE_NAME}")
 ORB_EVAL_SOURCE_PROFILE=$(circleci env subst "${ORB_EVAL_SOURCE_PROFILE}")
 if [ ! -f "${HOME}/.aws/credentials" ]; then
     echo "Credentials not found. Run setup command before role-arn-setup."
     exit 1
 fi
 
-aws configure set profile."${ORB_EVAL_PROFILE_NAME}".role_arn "${ORB_EVAL_ROLE_ARN}"
-aws configure set profile."${ORB_EVAL_PROFILE_NAME}".source_profile "${ORB_EVAL_SOURCE_PROFILE}"
+aws configure set profile."${ORB_STR_PROFILE_NAME}".role_arn "${ORB_STR_ROLE_ARN}"
+aws configure set profile."${ORB_STR_PROFILE_NAME}".source_profile "${ORB_EVAL_SOURCE_PROFILE}"

--- a/src/scripts/role_arn_setup.sh
+++ b/src/scripts/role_arn_setup.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 ORB_STR_ROLE_ARN="$(circleci env subst "${ORB_STR_ROLE_ARN}")"
 ORB_STR_PROFILE_NAME="$(circleci env subst "${ORB_STR_PROFILE_NAME}")"
-ORB_STR_SOURCE_PROFILE=$(circleci env subst "${ORB_STR_SOURCE_PROFILE}")
+ORB_STR_SOURCE_PROFILE="$(circleci env subst "${ORB_STR_SOURCE_PROFILE}")"
 
 if [ ! -f "${HOME}/.aws/credentials" ]; then
     echo "Credentials not found. Run setup command before role-arn-setup."


### PR DESCRIPTION
When a user specifies a shell for an executor in their config, using `shell: /bin/bash -o nounset` causes scripts with unbound variables to fail. 

This `PR` resolves this issue.