### PR TITLE
fix: set default region

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -144,7 +144,7 @@ workflows:
                   fi
       # Testing executors that do not AWS pre-installed
       - integration-test-install:
-          name: integration-test-web-identity-profile
+          name: integration-test-web-identity-with-profile
           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
           profile_name: "OIDC-User"
           context: [CPE-OIDC]

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -19,6 +19,12 @@ jobs:
         description: Select a specific version of the AWS v2 CLI. By default the latest version will be used.
         default: latest
         type: string
+      configure_default_region:
+        type: boolean
+        default: true
+      configure_profile_region:
+        type: boolean
+        default: true
       override_installed:
         type: boolean
         default: false
@@ -47,6 +53,9 @@ jobs:
         description: Profile name to be configured.
         type: string
         default: "default"
+      region:
+        type: string
+        default: ${AWS_DEFAULT_REGION}
     executor: <<parameters.executor>>
     steps:
       - aws-cli/setup:
@@ -58,6 +67,9 @@ jobs:
           profile_name: <<parameters.profile_name>>
           session_duration: <<parameters.session_duration>>
           role_session_name: <<parameters.role_session_name>>
+          configure_default_region: <<parameters.configure_default_region>>
+          configure_profile_region: <<parameters.configure_profile_region>>
+          region: <<parameters.region>>
       - test_paging
   integration-test-role-arn-setup:
     executor: docker-base
@@ -93,6 +105,25 @@ workflows:
   test-deploy:
     jobs:
       - integration-test-install:
+          name: integration-test-configure-profile-region
+          role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+          profile_name: "OIDC-User"
+          context: [CPE-OIDC]
+          configure_default_region: false
+          region: us-west-2
+          executor: docker-base
+          post-steps:
+            - run:
+                name: Checking ~/.aws/config for profile region
+                command: |
+                  if grep "\[profile OIDC-User\]" ~/.aws/config && grep "us-west-2" ~/.aws/config;then 
+                    echo "Profile region properly configured"
+                    exit 0
+                  else
+                    echo "Profile region not properly configured"
+                    exit 1
+                  fi
+      - integration-test-install:
           name: integration-test-configure-default-region
           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
           profile_name: "OIDC-User"
@@ -102,7 +133,7 @@ workflows:
           executor: docker-base
           post-steps:
             - run:
-                name: Checking ~/.aws/config for default region << parameters.region >>
+                name: Checking ~/.aws/config for default region
                 command: |
                   if grep "\[default\]" ~/.aws/config && grep "us-west-1" ~/.aws/config;then 
                     echo "Default region properly configured"
@@ -111,7 +142,7 @@ workflows:
                     echo "Default region not properly configured"
                     exit 1
                   fi
-      # # Testing executors that do not AWS pre-installed
+      # Testing executors that do not AWS pre-installed
       - integration-test-install:
           name: integration-test-web-identity-profile
           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
@@ -122,61 +153,61 @@ workflows:
             - run:
                 name: Web Identity Test - Logging into ECR
                 command: aws ecr get-login-password --region us-west-2 --profile "OIDC-User" | docker login --username AWS --password-stdin 122211685980.dkr.ecr.us-west-2.amazonaws.com
-      # # Testing executors that do not AWS pre-installed
-      # - integration-test-install:
-      #     name: integration-test-install-<<matrix.executor>>
-      #     context: [CPE_ORBS_AWS]
-      #     matrix:
-      #       alias: test-install
-      #       parameters:
-      #         executor: ["docker-base", "macos", "alpine"]
-      #     filters: *filters
-      #     post-steps:
-      #       - check_aws_version
-      # # Test installing specific versions on executors without AWS pre-installed
-      # - integration-test-install:
-      #     name: integration-test-install-version-<<matrix.executor>>
-      #     context: [CPE_ORBS_AWS]
-      #     matrix:
-      #       alias: test-install-version
-      #       parameters:
-      #         executor: ["docker-base", "macos", "alpine"]
-      #     version: "2.1.10"
-      #     filters: *filters
-      #     post-steps:
-      #       - check_aws_version:
-      #           version: "2.1.10"
-      # # Test overriding existing version of AWS pre-installed
-      # - integration-test-install:
-      #     name: integration-test-install-override-version-<<matrix.executor>>
-      #     context: [CPE_ORBS_AWS]
-      #     matrix:
-      #       alias: test-install-override-version
-      #       parameters:
-      #         executor: ["linuxvm", "windows", "arm"]
-      #     version: "2.1.10"
-      #     install_dir: "/usr/local/aws-cli"
-      #     binary_dir: ""
-      #     override_installed: true
-      #     filters: *filters
-      #     post-steps:
-      #       - check_aws_version:
-      #           version: "2.1.10"
-      # - integration-test-role-arn-setup:
-      #     name: integration-test-role_arn-config
-      #     profile_name: "CircleCI-Tester"
-      #     role_arn: ${ROLE_ARN}
-      #     context: [CPE_ORBS_AWS]
-      # - orb-tools/pack:
-      #     filters: *release-filters
-      # - orb-tools/publish:
-      #     orb_name: circleci/aws-cli
-      #     vcs_type: << pipeline.project.type >>
-      #     pub_type: production
-      #     enable_pr_comment: true
-      #     context: orb-publisher
-      #     requires: [orb-tools/pack, test-install, test-install-version, test-install-override-version, integration-test-web-identity-profile, integration-test-role_arn-config]
-      #     filters: *release-filters
+      # Testing executors that do not AWS pre-installed
+      - integration-test-install:
+          name: integration-test-install-<<matrix.executor>>
+          context: [CPE_ORBS_AWS]
+          matrix:
+            alias: test-install
+            parameters:
+              executor: ["docker-base", "macos", "alpine"]
+          filters: *filters
+          post-steps:
+            - check_aws_version
+      # Test installing specific versions on executors without AWS pre-installed
+      - integration-test-install:
+          name: integration-test-install-version-<<matrix.executor>>
+          context: [CPE_ORBS_AWS]
+          matrix:
+            alias: test-install-version
+            parameters:
+              executor: ["docker-base", "macos", "alpine"]
+          version: "2.1.10"
+          filters: *filters
+          post-steps:
+            - check_aws_version:
+                version: "2.1.10"
+      # Test overriding existing version of AWS pre-installed
+      - integration-test-install:
+          name: integration-test-install-override-version-<<matrix.executor>>
+          context: [CPE_ORBS_AWS]
+          matrix:
+            alias: test-install-override-version
+            parameters:
+              executor: ["linuxvm", "windows", "arm"]
+          version: "2.1.10"
+          install_dir: "/usr/local/aws-cli"
+          binary_dir: ""
+          override_installed: true
+          filters: *filters
+          post-steps:
+            - check_aws_version:
+                version: "2.1.10"
+      - integration-test-role-arn-setup:
+          name: integration-test-role_arn-config
+          profile_name: "CircleCI-Tester"
+          role_arn: ${ROLE_ARN}
+          context: [CPE_ORBS_AWS]
+      - orb-tools/pack:
+          filters: *release-filters
+      - orb-tools/publish:
+          orb_name: circleci/aws-cli
+          vcs_type: << pipeline.project.type >>
+          pub_type: production
+          enable_pr_comment: true
+          context: orb-publisher
+          requires: [orb-tools/pack, test-install, test-install-version, test-install-override-version, integration-test-web-identity-profile, integration-test-role_arn-config]
+          filters: *release-filters
 executors:
   alpine:
     docker:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -163,7 +163,6 @@ workflows:
             - run:
                 name: Web Identity Test - Logging into ECR
                 command: aws ecr get-login-password --region us-west-2 --profile "OIDC-Tester" | docker login --username AWS --password-stdin 122211685980.dkr.ecr.us-west-2.amazonaws.com
-          requires: [integration test web identity command with white spaces]
       # Testing executors that do not AWS CLI pre-installed
       - integration-test-install:
           name: integration-test-install-<<matrix.executor>>

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -102,61 +102,61 @@ workflows:
             - run:
                 name: Web Identity Test - Logging into ECR
                 command: aws ecr get-login-password --region us-west-2 --profile "OIDC-User" | docker login --username AWS --password-stdin 122211685980.dkr.ecr.us-west-2.amazonaws.com
-      # Testing executors that do not AWS pre-installed
-      - integration-test-install:
-          name: integration-test-install-<<matrix.executor>>
-          context: [CPE_ORBS_AWS]
-          matrix:
-            alias: test-install
-            parameters:
-              executor: ["docker-base", "macos", "alpine"]
-          filters: *filters
-          post-steps:
-            - check_aws_version
-      # Test installing specific versions on executors without AWS pre-installed
-      - integration-test-install:
-          name: integration-test-install-version-<<matrix.executor>>
-          context: [CPE_ORBS_AWS]
-          matrix:
-            alias: test-install-version
-            parameters:
-              executor: ["docker-base", "macos", "alpine"]
-          version: "2.1.10"
-          filters: *filters
-          post-steps:
-            - check_aws_version:
-                version: "2.1.10"
-      # Test overriding existing version of AWS pre-installed
-      - integration-test-install:
-          name: integration-test-install-override-version-<<matrix.executor>>
-          context: [CPE_ORBS_AWS]
-          matrix:
-            alias: test-install-override-version
-            parameters:
-              executor: ["linuxvm", "windows", "arm"]
-          version: "2.1.10"
-          install_dir: "/usr/local/aws-cli"
-          binary_dir: ""
-          override_installed: true
-          filters: *filters
-          post-steps:
-            - check_aws_version:
-                version: "2.1.10"
-      - integration-test-role-arn-setup:
-          name: integration-test-role_arn-config
-          profile_name: "CircleCI-Tester"
-          role_arn: ${ROLE_ARN}
-          context: [CPE_ORBS_AWS]
-      - orb-tools/pack:
-          filters: *release-filters
-      - orb-tools/publish:
-          orb_name: circleci/aws-cli
-          vcs_type: << pipeline.project.type >>
-          pub_type: production
-          enable_pr_comment: true
-          context: orb-publisher
-          requires: [orb-tools/pack, test-install, test-install-version, test-install-override-version, integration-test-web-identity-profile, integration-test-role_arn-config]
-          filters: *release-filters
+      # # Testing executors that do not AWS pre-installed
+      # - integration-test-install:
+      #     name: integration-test-install-<<matrix.executor>>
+      #     context: [CPE_ORBS_AWS]
+      #     matrix:
+      #       alias: test-install
+      #       parameters:
+      #         executor: ["docker-base", "macos", "alpine"]
+      #     filters: *filters
+      #     post-steps:
+      #       - check_aws_version
+      # # Test installing specific versions on executors without AWS pre-installed
+      # - integration-test-install:
+      #     name: integration-test-install-version-<<matrix.executor>>
+      #     context: [CPE_ORBS_AWS]
+      #     matrix:
+      #       alias: test-install-version
+      #       parameters:
+      #         executor: ["docker-base", "macos", "alpine"]
+      #     version: "2.1.10"
+      #     filters: *filters
+      #     post-steps:
+      #       - check_aws_version:
+      #           version: "2.1.10"
+      # # Test overriding existing version of AWS pre-installed
+      # - integration-test-install:
+      #     name: integration-test-install-override-version-<<matrix.executor>>
+      #     context: [CPE_ORBS_AWS]
+      #     matrix:
+      #       alias: test-install-override-version
+      #       parameters:
+      #         executor: ["linuxvm", "windows", "arm"]
+      #     version: "2.1.10"
+      #     install_dir: "/usr/local/aws-cli"
+      #     binary_dir: ""
+      #     override_installed: true
+      #     filters: *filters
+      #     post-steps:
+      #       - check_aws_version:
+      #           version: "2.1.10"
+      # - integration-test-role-arn-setup:
+      #     name: integration-test-role_arn-config
+      #     profile_name: "CircleCI-Tester"
+      #     role_arn: ${ROLE_ARN}
+      #     context: [CPE_ORBS_AWS]
+      # - orb-tools/pack:
+      #     filters: *release-filters
+      # - orb-tools/publish:
+      #     orb_name: circleci/aws-cli
+      #     vcs_type: << pipeline.project.type >>
+      #     pub_type: production
+      #     enable_pr_comment: true
+      #     context: orb-publisher
+      #     requires: [orb-tools/pack, test-install, test-install-version, test-install-override-version, integration-test-web-identity-profile, integration-test-role_arn-config]
+      #     filters: *release-filters
 executors:
   alpine:
     docker:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -156,13 +156,13 @@ workflows:
       - integration-test-install:
           name: integration-test-web-identity-with-profile
           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-          profile_name: "OIDC-User"
+          profile_name: "OIDC_Tester"
           context: [CPE-OIDC]
           executor: docker-base
           post-steps:
             - run:
                 name: Web Identity Test - Logging into ECR
-                command: aws ecr get-login-password --region us-west-2 --profile "OIDC-User" | docker login --username AWS --password-stdin 122211685980.dkr.ecr.us-west-2.amazonaws.com
+                command: aws ecr get-login-password --region us-west-2 --profile "OIDC-Tester" | docker login --username AWS --password-stdin 122211685980.dkr.ecr.us-west-2.amazonaws.com
           requires: [integration test web identity command with white spaces]
       # Testing executors that do not AWS CLI pre-installed
       - integration-test-install:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -93,6 +93,26 @@ workflows:
   test-deploy:
     jobs:
       - integration-test-install:
+          name: integration-test-configure-default-region
+          role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+          profile_name: "OIDC-User"
+          context: [CPE-OIDC]
+          configure_profile_region: false
+          region: us-west-1
+          executor: docker-base
+          post-steps:
+            - run:
+                name: Checking ~/.aws/config for default region << parameters.region >>
+                command: |
+                  if grep "\[default\]" ~/.aws/config && grep "us-west-1" ~/.aws/config;then 
+                    echo "Default region properly configured"
+                    exit 0
+                  else
+                    echo "Default region not properly configured"
+                    exit 1
+                  fi
+      # # Testing executors that do not AWS pre-installed
+      - integration-test-install:
           name: integration-test-web-identity-profile
           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
           profile_name: "OIDC-User"

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -163,6 +163,7 @@ workflows:
             - run:
                 name: Web Identity Test - Logging into ECR
                 command: aws ecr get-login-password --region us-west-2 --profile "OIDC-User" | docker login --username AWS --password-stdin 122211685980.dkr.ecr.us-west-2.amazonaws.com
+          requires: [integration test web identity command with white spaces]
       # Testing executors that do not AWS CLI pre-installed
       - integration-test-install:
           name: integration-test-install-<<matrix.executor>>

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -104,6 +104,7 @@ jobs:
 workflows:
   test-deploy:
     jobs:
+      # Testing region configuration
       - integration-test-install:
           name: integration-test-configure-profile-region
           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
@@ -142,7 +143,16 @@ workflows:
                     echo "Default region not properly configured"
                     exit 1
                   fi
-      # Testing executors that do not AWS pre-installed
+      # Testing OIDC
+      - integration-test-install:
+          name: integration test web identity command with white spaces
+          role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+          context: [CPE-OIDC]
+          executor: docker-base
+          post-steps:
+            - run:
+                name: Web Identity Test - Logging into ECR
+                command: aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin 122211685980.dkr.ecr.us-west-2.amazonaws.com
       - integration-test-install:
           name: integration-test-web-identity-with-profile
           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
@@ -153,7 +163,7 @@ workflows:
             - run:
                 name: Web Identity Test - Logging into ECR
                 command: aws ecr get-login-password --region us-west-2 --profile "OIDC-User" | docker login --username AWS --password-stdin 122211685980.dkr.ecr.us-west-2.amazonaws.com
-      # Testing executors that do not AWS pre-installed
+      # Testing executors that do not AWS CLI pre-installed
       - integration-test-install:
           name: integration-test-install-<<matrix.executor>>
           context: [CPE_ORBS_AWS]

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -156,7 +156,7 @@ workflows:
       - integration-test-install:
           name: integration-test-web-identity-with-profile
           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-          profile_name: "OIDC_Tester"
+          profile_name: "OIDC-Tester"
           context: [CPE-OIDC]
           executor: docker-base
           post-steps:

--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -52,7 +52,7 @@ parameters:
       the environment variable you will use to hold this
       value, i.e. AWS_SECRET_ACCESS_KEY.
     type: string
-    default: $(AWS_SECRET_ACCESS_KEY}
+    default: ${AWS_SECRET_ACCESS_KEY}
 
   region:
     description: |

--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -64,12 +64,14 @@ parameters:
   configure_default_region:
     description: |
       Some AWS actions don't require a region; set this to false if you do not want to store a default region in ~/.aws/config
+      Any AWS cli command will default to this region if none is specified with the --region cli parameter. 
     type: boolean
     default: true
 
   configure_profile_region:
     description: |
-      Boolean whether to configure the region for the custom (non-default) profile or not
+      Boolean whether to configure the region for the custom (non-default) profile. The specified region will be used for AWS cli
+      commands executed under that specific profile using the --profile cli parameter.
     type: boolean
     default: true
 

--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -64,7 +64,7 @@ parameters:
   configure_default_region:
     description: |
       Some AWS actions don't require a region; set this to false if you do not want to store a default region in ~/.aws/config
-      Any AWS cli command will default to this region if none is specified with the --region cli parameter.
+      Any AWS CLI command will default to this region if none is specified with the --region CLI parameter.
     type: boolean
     default: true
 

--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -70,8 +70,8 @@ parameters:
 
   configure_profile_region:
     description: |
-      Boolean whether to configure the region for the custom (non-default) profile. The specified region will be used for AWS cli
-      commands executed under that specific profile using the --profile cli parameter.
+      Boolean whether to configure the region for the custom (non-default) profile. The specified region will be used for AWS CLI
+      commands executed under that specific profile using the --profile CLI parameter.
     type: boolean
     default: true
 

--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -43,7 +43,7 @@ parameters:
       AWS access key id for IAM role. Set this to the name of
       the environment variable you will use to hold this
       value, i.e. AWS_ACCESS_KEY.
-    type: string_name
+    type: string
     default: ${AWS_ACCESS_KEY_ID}
 
   aws_secret_access_key:
@@ -51,7 +51,7 @@ parameters:
       AWS secret key for IAM role. Set this to the name of
       the environment variable you will use to hold this
       value, i.e. AWS_SECRET_ACCESS_KEY.
-    type: string_name
+    type: string
     default: $(AWS_SECRET_ACCESS_KEY}
 
   region:

--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -43,16 +43,16 @@ parameters:
       AWS access key id for IAM role. Set this to the name of
       the environment variable you will use to hold this
       value, i.e. AWS_ACCESS_KEY.
-    type: env_var_name
-    default: AWS_ACCESS_KEY_ID
+    type: string_name
+    default: ${AWS_ACCESS_KEY_ID}
 
   aws_secret_access_key:
     description: |
       AWS secret key for IAM role. Set this to the name of
       the environment variable you will use to hold this
       value, i.e. AWS_SECRET_ACCESS_KEY.
-    type: env_var_name
-    default: AWS_SECRET_ACCESS_KEY
+    type: string_name
+    default: $(AWS_SECRET_ACCESS_KEY}
 
   region:
     description: |
@@ -113,8 +113,8 @@ steps:
   - run:
       name: Configure AWS Access Key ID
       environment:
-        ORB_ENV_ACCESS_KEY_ID: <<parameters.aws_access_key_id>>
-        ORB_ENV_SECRET_ACCESS_KEY: <<parameters.aws_secret_access_key>>
+        ORB_STR_ACCESS_KEY_ID: <<parameters.aws_access_key_id>>
+        ORB_STR_SECRET_ACCESS_KEY: <<parameters.aws_secret_access_key>>
         ORB_STR_PROFILE_NAME: <<parameters.profile_name>>
         ORB_BOOL_CONFIG_DEFAULT_REGION: <<parameters.configure_default_region>>
         ORB_BOOL_CONFIG_PROFILE_REGION: <<parameters.configure_profile_region>>

--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -64,7 +64,7 @@ parameters:
   configure_default_region:
     description: |
       Some AWS actions don't require a region; set this to false if you do not want to store a default region in ~/.aws/config
-      Any AWS cli command will default to this region if none is specified with the --region cli parameter. 
+      Any AWS cli command will default to this region if none is specified with the --region cli parameter.
     type: boolean
     default: true
 

--- a/src/scripts/configure.sh
+++ b/src/scripts/configure.sh
@@ -5,23 +5,24 @@ if grep "Alpine" /etc/issue > /dev/null 2>&1; then
     . "$BASH_ENV"
 fi
 
-ORB_ENV_ACCESS_KEY_ID=$(circleci env subst "\$$ORB_ENV_ACCESS_KEY_ID")
-ORB_ENV_SECRET_ACCESS_KEY=$(circleci env subst "\$$ORB_ENV_SECRET_ACCESS_KEY")
+ORB_STR_ACCESS_KEY_ID=$(circleci env subst "$ORB_STR_ACCESS_KEY_ID")
+ORB_STR_SECRET_ACCESS_KEY=$(circleci env subst "$ORB_STR_SECRET_ACCESS_KEY")
 AWS_SESSION_TOKEN="$(circleci env subst "$AWS_SESSION_TOKEN")"
-ORB_STR_REGION="$(circleci env subst "\$$ORB_STR_REGION")"
+ORB_STR_REGION="$(circleci env subst "$ORB_STR_REGION")"
 ORB_STR_PROFILE_NAME="$(circleci env subst "$ORB_STR_PROFILE_NAME")"
 
-if [ -z "$ORB_ENV_ACCESS_KEY_ID" ] || [ -z "${ORB_ENV_SECRET_ACCESS_KEY}" ]; then 
+if [ -z "$ORB_STR_ACCESS_KEY_ID" ] || [ -z "${ORB_STR_SECRET_ACCESS_KEY}" ]; then 
     echo "Cannot configure profile. AWS access key id and AWS secret access key must be provided."
     exit 1
 fi
 
+set -x
 aws configure set aws_access_key_id \
-    "$ORB_ENV_ACCESS_KEY_ID" \
+    "$ORB_STR_ACCESS_KEY_ID" \
     --profile "$ORB_STR_PROFILE_NAME"
 
 aws configure set aws_secret_access_key \
-    "$ORB_ENV_SECRET_ACCESS_KEY" \
+    "$ORB_STR_SECRET_ACCESS_KEY" \
     --profile "$ORB_STR_PROFILE_NAME"
 
 if [ -n "${AWS_SESSION_TOKEN}" ]; then
@@ -31,11 +32,11 @@ if [ -n "${AWS_SESSION_TOKEN}" ]; then
 fi
 
 if [ "$ORB_BOOL_CONFIG_DEFAULT_REGION" = "1" ]; then
-    aws configure set default.region "$ORB_STR_REGION" \
-        --profile "$ORB_STR_PROFILE_NAME"
+    aws configure set default.region "$ORB_STR_REGION"
 fi
 
 if [ "$ORB_BOOL_CONFIG_PROFILE_REGION" = "1" ]; then
     aws configure set region "$ORB_STR_REGION" \
         --profile "$ORB_STR_PROFILE_NAME"
 fi
+set +x

--- a/src/scripts/configure.sh
+++ b/src/scripts/configure.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-#shellcheck disable=#SC1090
+#shellcheck disable=SC1090
 if grep "Alpine" /etc/issue > /dev/null 2>&1; then
     touch "$BASH_ENV"
     . "$BASH_ENV"

--- a/src/scripts/configure.sh
+++ b/src/scripts/configure.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+#shellcheck disable=#SC1090
 if grep "Alpine" /etc/issue > /dev/null 2>&1; then
     touch "$BASH_ENV"
     . "$BASH_ENV"

--- a/src/scripts/configure.sh
+++ b/src/scripts/configure.sh
@@ -16,7 +16,6 @@ if [ -z "$ORB_STR_ACCESS_KEY_ID" ] || [ -z "${ORB_STR_SECRET_ACCESS_KEY}" ]; the
     exit 1
 fi
 
-set -x
 aws configure set aws_access_key_id \
     "$ORB_STR_ACCESS_KEY_ID" \
     --profile "$ORB_STR_PROFILE_NAME"
@@ -39,4 +38,3 @@ if [ "$ORB_BOOL_CONFIG_PROFILE_REGION" = "1" ]; then
     aws configure set region "$ORB_STR_REGION" \
         --profile "$ORB_STR_PROFILE_NAME"
 fi
-set +x

--- a/src/scripts/configure.sh
+++ b/src/scripts/configure.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-# shellcheck disable=SC1090
 if grep "Alpine" /etc/issue > /dev/null 2>&1; then
     touch "$BASH_ENV"
     . "$BASH_ENV"

--- a/src/scripts/configure.sh
+++ b/src/scripts/configure.sh
@@ -30,8 +30,7 @@ if [ -n "${AWS_SESSION_TOKEN}" ]; then
 fi
 
 if [ "$ORB_VAL_CONFIG_DEFAULT_REGION" = "1" ]; then
-    aws configure set default.region "$ORB_EVAL_AWS_CLI_REGION" \
-        --profile "$ORB_EVAL_PROFILE_NAME"
+    aws configure set default.region "$ORB_EVAL_AWS_CLI_REGION"
 fi
 
 if [ "$ORB_VAL_CONFIG_PROFILE_REGION" = "1" ]; then

--- a/src/scripts/configure.sh
+++ b/src/scripts/configure.sh
@@ -7,7 +7,7 @@ fi
 
 ORB_ENV_ACCESS_KEY_ID=$(circleci env subst "\$$ORB_ENV_ACCESS_KEY_ID")
 ORB_ENV_SECRET_ACCESS_KEY=$(circleci env subst "\$$ORB_ENV_SECRET_ACCESS_KEY")
-ORB_EVAL_AWS_CLI_REGION=$(circleci env subst "\$$ORB_EVAL_AWS_CLI_REGION")
+ORB_EVAL_AWS_CLI_REGION=$(circleci env subst "$ORB_EVAL_AWS_CLI_REGION")
 ORB_EVAL_PROFILE_NAME=$(circleci env subst "$ORB_EVAL_PROFILE_NAME")
 
 if [ -z "$ORB_ENV_ACCESS_KEY_ID" ] || [ -z "${ORB_ENV_SECRET_ACCESS_KEY}" ]; then 


### PR DESCRIPTION
This `PR` updates the descriptions of the `configure_default_region` and the `configure_profile_region` parameters. It also removed the `--profile` flag from the `aws configure set default.region` cli command in the `configure.sh` script. Lastly, it adds testing and validation for configuring both the default region and the profile region. 



Currently, there's some confusion regarding the configuration of the `default region` versus the `profile region`. 

According to the `AWS` Documentation: 

**`aws configure set default.region`**:
 
- This command sets the default region for the AWS CLI. The specified region will be used by default for all AWS CLI commands unless overridden.
-The value set using default.region is stored in the AWS CLI configuration file (`~/.aws/config`), specifically in the `[default]` section.
-Example usage: `aws configure set default.region us-west-2`

**`aws configure set region`**:

- This command sets the region for the current profile in the AWS CLI configuration. The specified region will be used for commands executed under that specific profile.
-The value set using region is stored in the AWS CLI configuration file (`~/.aws/config`) within the specific profile section.
-Example usage: `aws configure set region us-west-2 --profile myprofile`

In summary, `aws configure set default.region` sets the default region for all commands executed by the AWS CLI, while `aws configure set region` sets the region for a specific profile.

