### PR TITLE
chore: update MacOS executor to use Gen2

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -235,6 +235,7 @@ executors:
   macos:
     macos:
       xcode: 13.3.0
+    resource_class: macos.x86.medium.gen2
   arm:
     machine:
       image: ubuntu-2004:202101-01


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

The MacOS tests for this orb are still making use of the [deprecated](https://discuss.circleci.com/t/macos-resource-deprecation-update/46891) medium MacOS resource class.

This version will not have any further [Xcode version support](https://discuss.circleci.com/t/reminder-no-new-xcode-version-support-on-macos-medium-large-resources/46890) and as such, we should set an example by updating to the Gen2 resource class.

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

Add a `resource_class` stanza to update the various MacOS tests to use `macos.x86.medium.gen2` from `medium`
