### PR TITLE
ADD region flag to assume-role-with-web-identity

### DIFF
--- a/src/commands/assume_role_with_web_identity.yml
+++ b/src/commands/assume_role_with_web_identity.yml
@@ -26,6 +26,13 @@ parameters:
     type: string
     default: "default"
 
+  region:
+    description: |
+      AWS region to operate in
+      (defaults to env var of ${AWS_DEFAULT_REGION})
+    type: string
+    default: ${AWS_DEFAULT_REGION}
+
 steps:
   - run:
       name: Generate shortlived AWS Keys using CircleCI OIDC token.
@@ -34,4 +41,5 @@ steps:
         ORB_STR_ROLE_SESSION_NAME: <<parameters.role_session_name>>
         ORB_INT_SESSION_DURATION: <<parameters.session_duration>>
         ORB_STR_PROFILE_NAME: <<parameters.profile_name>>
+        ORB_STR_REGION: <<parameters.region>>
       command: <<include(scripts/assume_role_with_web_identity.sh)>>

--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -110,6 +110,7 @@ steps:
             role_session_name: <<parameters.role_session_name>>
             session_duration: <<parameters.session_duration>>
             profile_name: <<parameters.profile_name>>
+            region: <<parameters.region>>
   - run:
       name: Configure AWS Access Key ID
       environment:

--- a/src/scripts/assume_role_with_web_identity.sh
+++ b/src/scripts/assume_role_with_web_identity.sh
@@ -28,6 +28,7 @@ $(aws sts assume-role-with-web-identity \
 --web-identity-token "${CIRCLE_OIDC_TOKEN_V2}" \
 --duration-seconds "${ORB_INT_SESSION_DURATION}" \
 --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' \
+--region "${ORB_STR_REGION}" \
 --output text)
 EOF
 


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

Switching `AWS_REGION` environment variable so that the `assume-role-with-web-identity` command can run without the region flag is cumbersome. 

### Description

add region flag to `assume-role-with-web-identity` cli call. This will remove the need to update environment variables when targeting non-default regions.
