### PR TITLE
Allow override_installed without specifying version

### DIFF
--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -141,10 +141,14 @@ if [ ! "$(command -v aws)" ]; then
     fi
 elif [ "$ORB_BOOL_OVERRIDE" -eq 1 ]; then
     Uninstall_AWS_CLI
-    if uname -a | grep "x86_64 Msys"; then
-        Install_AWS_CLI "${ORB_STR_AWS_CLI_VERSION}"
+    if [ "$ORB_STR_AWS_CLI_VERSION" = "latest" ]; then
+        Install_AWS_CLI ""
     else
-        Install_AWS_CLI "-${ORB_STR_AWS_CLI_VERSION}"
+        if uname -a | grep "x86_64 Msys"; then
+            Install_AWS_CLI "${ORB_STR_AWS_CLI_VERSION}"
+        else
+            Install_AWS_CLI "-${ORB_STR_AWS_CLI_VERSION}"
+        fi
     fi
 else
     echo "AWS CLI is already installed, skipping installation."


### PR DESCRIPTION


### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

This install command will not work:

```
- aws-cli/install:
    override_installed: true
```

It will attempt to download the zipfile from a path including "latest", eg `https://awscli.amazonaws.com/awscli-exe-linux-x86_64latest.zip`. There's no zipfile there.

### Description

In the `install` command, if `override_installed` is set to `true` but `version` is not specified, the orb will attempt to download the AWS CLI from a path including "latest". Change this behavior so that it instead does not include any version identifier in the zipfile URL.

This behavior already exists here, but the functionality was never added to the block reached when `override_installed` is set to true: https://github.com/CircleCI-Public/aws-cli-orb/blob/8f0d172b929d87457b64c027390e3bdcb3eb8ef9/src/scripts/install.sh#L133-L135