### PR TITLE
fix: install specified version

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -156,13 +156,13 @@ workflows:
       - integration-test-install:
           name: integration-test-web-identity-with-profile
           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-          profile_name: OIDC-Tester
+          profile_name: "OIDC-Tester"
           context: [CPE-OIDC]
           executor: docker-base
           post-steps:
             - run:
                 name: Web Identity Test - Logging into ECR
-                command: aws ecr get-login-password --region us-west-2 --profile OIDC-Tester | docker login --username AWS --password-stdin 122211685980.dkr.ecr.us-west-2.amazonaws.com
+                command: aws ecr get-login-password --region us-west-2 --profile "OIDC-Tester" | docker login --username AWS --password-stdin 122211685980.dkr.ecr.us-west-2.amazonaws.com
       # Testing executors that do not AWS CLI pre-installed
       - integration-test-install:
           name: integration-test-install-<<matrix.executor>>

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -198,7 +198,7 @@ workflows:
           version: "2.1.10"
           install_dir: "/usr/local/aws-cli"
           binary_dir: ""
-          override_installed: true
+          override_installed: false
           filters: *filters
           post-steps:
             - check_aws_version:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -156,13 +156,13 @@ workflows:
       - integration-test-install:
           name: integration-test-web-identity-with-profile
           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-          profile_name: "OIDC-Tester"
+          profile_name: OIDC-Tester
           context: [CPE-OIDC]
           executor: docker-base
           post-steps:
             - run:
                 name: Web Identity Test - Logging into ECR
-                command: aws ecr get-login-password --region us-west-2 --profile "OIDC-Tester" | docker login --username AWS --password-stdin 122211685980.dkr.ecr.us-west-2.amazonaws.com
+                command: aws ecr get-login-password --region us-west-2 --profile OIDC-Tester | docker login --username AWS --password-stdin 122211685980.dkr.ecr.us-west-2.amazonaws.com
       # Testing executors that do not AWS CLI pre-installed
       - integration-test-install:
           name: integration-test-install-<<matrix.executor>>

--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -44,7 +44,7 @@ parameters:
       the environment variable you will use to hold this
       value, i.e. AWS_ACCESS_KEY.
     type: string
-    default: ${AWS_ACCESS_KEY_ID}
+    default: AWS_ACCESS_KEY_ID
 
   aws_secret_access_key:
     description: |
@@ -52,7 +52,7 @@ parameters:
       the environment variable you will use to hold this
       value, i.e. AWS_SECRET_ACCESS_KEY.
     type: string
-    default: ${AWS_SECRET_ACCESS_KEY}
+    default: AWS_SECRET_ACCESS_KEY
 
   region:
     description: |

--- a/src/scripts/assume_role_with_web_identity.sh
+++ b/src/scripts/assume_role_with_web_identity.sh
@@ -23,7 +23,6 @@ if [ ! "$(command -v aws)" ]; then
 fi
 
 if [ -n "${AWS_CLI_STR_REGION}" ]; then
-    echo "${AWS_CLI_STR_REGION}"
     set -- "$@" --region "${AWS_CLI_STR_REGION}"
 fi
 

--- a/src/scripts/assume_role_with_web_identity.sh
+++ b/src/scripts/assume_role_with_web_identity.sh
@@ -4,9 +4,9 @@ AWS_CLI_STR_ROLE_ARN="$(echo "${AWS_CLI_STR_ROLE_ARN}" | circleci env subst)"
 AWS_CLI_STR_PROFILE_NAME="$(echo "${AWS_CLI_STR_PROFILE_NAME}" | circleci env subst)"
 AWS_CLI_STR_REGION="$(echo "${AWS_CLI_STR_REGION}" | circleci env subst)"
 
+
 # Replaces white spaces in role session name with dashes
 AWS_CLI_STR_ROLE_SESSION_NAME=$(echo "${AWS_CLI_STR_ROLE_SESSION_NAME}" | tr ' ' '-')
-
 if [ -z "${AWS_CLI_STR_ROLE_SESSION_NAME}" ]; then
     echo "Role session name is required"
     exit 1
@@ -23,6 +23,7 @@ if [ ! "$(command -v aws)" ]; then
 fi
 
 if [ -n "${AWS_CLI_STR_REGION}" ]; then
+    echo "${AWS_CLI_STR_REGION}"
     set -- "$@" --region "${AWS_CLI_STR_REGION}"
 fi
 

--- a/src/scripts/configure.sh
+++ b/src/scripts/configure.sh
@@ -5,8 +5,8 @@ if grep "Alpine" /etc/issue > /dev/null 2>&1; then
     . "$BASH_ENV"
 fi
 
-AWS_CLI_STR_ACCESS_KEY_ID="$(echo "$AWS_CLI_STR_ACCESS_KEY_ID" | circleci env subst)"
-AWS_CLI_STR_SECRET_ACCESS_KEY="$(echo "$AWS_CLI_STR_SECRET_ACCESS_KEY" | circleci env subst)"
+AWS_CLI_STR_ACCESS_KEY_ID="$(echo "\$$AWS_CLI_STR_ACCESS_KEY_ID" | circleci env subst)"
+AWS_CLI_STR_SECRET_ACCESS_KEY="$(echo "\$$AWS_CLI_STR_SECRET_ACCESS_KEY" | circleci env subst)"
 AWS_SESSION_TOKEN="$(echo "$AWS_SESSION_TOKEN" | circleci env subst)"
 AWS_CLI_STR_REGION="$(echo "$AWS_CLI_STR_REGION" | circleci env subst)"
 AWS_CLI_STR_PROFILE_NAME="$(echo "$AWS_CLI_STR_PROFILE_NAME" | circleci env subst)"
@@ -15,7 +15,7 @@ if [ -z "$AWS_CLI_STR_ACCESS_KEY_ID" ] || [ -z "${AWS_CLI_STR_SECRET_ACCESS_KEY}
     echo "Cannot configure profile. AWS access key id and AWS secret access key must be provided."
     exit 1
 fi
-set -x
+
 aws configure set aws_access_key_id \
     "$AWS_CLI_STR_ACCESS_KEY_ID" \
     --profile "$AWS_CLI_STR_PROFILE_NAME"
@@ -39,4 +39,3 @@ if [ "$AWS_CLI_BOOL_CONFIG_PROFILE_REGION" -eq "1" ]; then
     aws configure set region "$AWS_CLI_STR_REGION" \
         --profile "$AWS_CLI_STR_PROFILE_NAME"
 fi
-set +x

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -34,7 +34,7 @@ Toggle_Pager(){
 if ! command -v aws >/dev/null 2>&1; then
     Install_AWS_CLI "${AWS_CLI_STR_AWS_CLI_VERSION}"
     Toggle_Pager
-elif [ "$AWS_CLI_BOOL_OVERRIDE" -eq 1 ]; then
+elif [ "$AWS_CLI_BOOL_OVERRIDE" -eq 1 ] || [ "${AWS_CLI_STR_AWS_CLI_VERSION}" != "latest" ]; then
     Uninstall_AWS_CLI
     Install_AWS_CLI "${AWS_CLI_STR_AWS_CLI_VERSION}"
     Toggle_Pager

--- a/src/scripts/role_arn_setup.sh
+++ b/src/scripts/role_arn_setup.sh
@@ -7,7 +7,7 @@ if [ ! -f "${HOME}/.aws/credentials" ]; then
     echo "Credentials not found. Run setup command before role-arn-setup."
     exit 1
 fi
-set -x
+
 aws configure set profile."${AWS_CLI_STR_PROFILE_NAME}".role_arn "${AWS_CLI_STR_ROLE_ARN}"
 aws configure set profile."${AWS_CLI_STR_PROFILE_NAME}".source_profile "${AWS_CLI_STR_SOURCE_PROFILE}"
-set +x
+


### PR DESCRIPTION
Currently, the orb does install the `aws cli` version that's specified by the user. This `PR` fixes this issue.