### PR TITLE
refactor:write oidc credentials to temp file

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -70,7 +70,16 @@ jobs:
           configure_default_region: <<parameters.configure_default_region>>
           configure_profile_region: <<parameters.configure_profile_region>>
           region: <<parameters.region>>
-      - test_paging
+      - run:
+          name: Test that paging is disabled
+          command: |-
+            # Test with aws command that would require paging if a pager is enabled
+            touch "${BASH_ENV}"
+            . "${BASH_ENV}"
+            aws --version
+            aws ec2 describe-images --profile << parameters.profile_name >> \
+              --owners amazon \
+              --filters "Name=platform,Values=windows" "Name=root-device-type,Values=ebs"
   integration-test-role-arn-setup:
     executor: docker-base
     parameters:
@@ -264,16 +273,3 @@ commands:
             else
               if ! command -v aws &> /dev/null; then exit 1; else exit 0; fi
             fi
-  test_paging:
-    steps:
-      - run:
-          name: Test that paging is disabled
-          command: |-
-            # Test with aws command that would require paging if a pager is enabled
-            if cat /etc/issue | grep "Alpine" || uname -a | grep "x86_64 Msys"; then
-              source $BASH_ENV
-            fi
-            aws --version
-            aws ec2 describe-images \
-              --owners amazon \
-              --filters "Name=platform,Values=windows" "Name=root-device-type,Values=ebs"

--- a/src/scripts/assume_role_with_web_identity.sh
+++ b/src/scripts/assume_role_with_web_identity.sh
@@ -37,14 +37,17 @@ $(aws sts assume-role-with-web-identity \
 --output text)
 EOF
 
+temp_file="/tmp/${AWS_CLI_STR_PROFILE_NAME}.keys"
+touch "$temp_file"
+
 if [ -z "${AWS_ACCESS_KEY_ID}" ] || [ -z "${AWS_SECRET_ACCESS_KEY}" ] || [ -z "${AWS_SESSION_TOKEN}" ]; then
     echo "Failed to assume role";
     exit 1
 else 
     {
-        echo "export AWS_ACCESS_KEY_ID=\"${AWS_ACCESS_KEY_ID}\""
-        echo "export AWS_SECRET_ACCESS_KEY=\"${AWS_SECRET_ACCESS_KEY}\""
-        echo "export AWS_SESSION_TOKEN=\"${AWS_SESSION_TOKEN}\""
-    } >>"$BASH_ENV"
+        echo "export AWS_CLI_STR_ACCESS_KEY_ID=\"${AWS_ACCESS_KEY_ID}\""
+        echo "export AWS_CLI_STR_SECRET_ACCESS_KEY=\"${AWS_SECRET_ACCESS_KEY}\""
+        echo "export AWS_CLI_STR_SESSION_TOKEN=\"${AWS_SESSION_TOKEN}\""
+    }  >> "$temp_file"
     echo "Assume role with web identity succeeded"
 fi

--- a/src/scripts/configure.sh
+++ b/src/scripts/configure.sh
@@ -1,19 +1,14 @@
 #!/bin/sh
 #shellcheck disable=SC1090
-if grep "Alpine" /etc/issue > /dev/null 2>&1; then
-    touch "$BASH_ENV"
-    . "$BASH_ENV"
-fi
-
 AWS_CLI_STR_ACCESS_KEY_ID="$(echo "\$$AWS_CLI_STR_ACCESS_KEY_ID" | circleci env subst)"
 AWS_CLI_STR_SECRET_ACCESS_KEY="$(echo "\$$AWS_CLI_STR_SECRET_ACCESS_KEY" | circleci env subst)"
-AWS_SESSION_TOKEN="$(echo "$AWS_SESSION_TOKEN" | circleci env subst)"
+AWS_CLI_STR_SESSION_TOKEN="$(echo "$AWS_CLI_STR_SESSION_TOKEN" | circleci env subst)"
 AWS_CLI_STR_REGION="$(echo "$AWS_CLI_STR_REGION" | circleci env subst)"
 AWS_CLI_STR_PROFILE_NAME="$(echo "$AWS_CLI_STR_PROFILE_NAME" | circleci env subst)"
 
-if [ -z "$AWS_CLI_STR_ACCESS_KEY_ID" ] || [ -z "${AWS_CLI_STR_SECRET_ACCESS_KEY}" ]; then 
-    echo "Cannot configure profile. AWS access key id and AWS secret access key must be provided."
-    exit 1
+if [ -z "$AWS_CLI_STR_ACCESS_KEY_ID" ] && [ -z "${AWS_CLI_STR_SECRET_ACCESS_KEY}" ]; then 
+    temp_file="/tmp/${AWS_CLI_STR_PROFILE_NAME}.keys"
+    . "$temp_file"
 fi
 
 aws configure set aws_access_key_id \
@@ -24,12 +19,11 @@ aws configure set aws_secret_access_key \
     "$AWS_CLI_STR_SECRET_ACCESS_KEY" \
     --profile "$AWS_CLI_STR_PROFILE_NAME"
 
-if [ -n "${AWS_SESSION_TOKEN}" ]; then
+if [ -n "${AWS_CLI_STR_SESSION_TOKEN}" ]; then
     aws configure set aws_session_token \
-        "${AWS_SESSION_TOKEN}" \
+        "${AWS_CLI_STR_SESSION_TOKEN}" \
         --profile "$AWS_CLI_STR_PROFILE_NAME"
 fi
-
 
 if [ "$AWS_CLI_BOOL_CONFIG_DEFAULT_REGION" -eq "1" ]; then
     aws configure set default.region "$AWS_CLI_STR_REGION"
@@ -39,3 +33,4 @@ if [ "$AWS_CLI_BOOL_CONFIG_PROFILE_REGION" -eq "1" ]; then
     aws configure set region "$AWS_CLI_STR_REGION" \
         --profile "$AWS_CLI_STR_PROFILE_NAME"
 fi
+

--- a/src/scripts/linux/install.sh
+++ b/src/scripts/linux/install.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+#shellcheck disable=SC1090
 Install_AWS_CLI() {
     if [ "$1" = "latest" ]; then
         version=""


### PR DESCRIPTION
The current version of the orb exports the `OIDC` credentials to `$BASH_ENV`. 

In cases where multiple profiles are created, some `aws` commands will use the credentials from `$BASH_ENV` by default, bypassing any profiles that's specified. 

This `PR` writes the generated `OIDC` keys to a temporary file that's `sourced` to complete the configuration process.

