### PR TITLE
ci: add more testing for role_arn_setup command

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -79,7 +79,7 @@ jobs:
             aws --version
             aws ec2 describe-images --profile << parameters.profile_name >> \
               --owners amazon \
-              --filters "Name=platform,Values=windows" "Name=root-device-type,Values=ebs"
+              --filters "Name=platform,Values=windows" "Name=root-device-type,Values=ebs" 
   integration-test-role-arn-setup:
     executor: docker-base
     parameters:
@@ -97,6 +97,7 @@ jobs:
       - aws-cli/setup
       - aws-cli/role_arn_setup:
           profile_name: <<parameters.profile_name>>
+          source_profile: <<parameters.source_profile>>
           role_arn: <<parameters.role_arn>>
       - run:
           name: Check if profiles were created
@@ -214,9 +215,14 @@ workflows:
                 version: "2.1.10"
       - integration-test-role-arn-setup:
           name: integration-test-role-arn-config
-          profile_name: "CircleCI-Tester"
-          role_arn: ${ROLE_ARN}
+          source_profile: default
+          profile_name: CircleCI-Tester
+          role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
           context: [CPE_ORBS_AWS]
+          post-steps:
+            - run:
+                  name: Logging into ECR with new profile
+                  command: aws ecr get-login-password --region us-west-2 --profile "CircleCI-Tester" | docker login --username AWS --password-stdin 122211685980.dkr.ecr.us-west-2.amazonaws.com
       - orb-tools/pack:
           filters: *release-filters
       - orb-tools/publish:

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -4,7 +4,7 @@ description: |
   Install and configure the AWS command-line interface (awscli) version 2.
   (To use AWS CLI v1 view version 1.4.1 of this orb)
 
-  Supports Linux x86_64, MacOS, and Arm64 V8.
+  Supports Linux x86_64, MacOS, Arm64 V8 and Windows with bash.exe
 
 display:
   source_url: https://github.com/CircleCI-Public/aws-cli-orb

--- a/src/examples/configure_role_arn.yml
+++ b/src/examples/configure_role_arn.yml
@@ -1,4 +1,6 @@
-description: Configure a new profile to assume a role defined by a role_arn.
+description: | 
+  Configure a new profile to assume a role defined by a role_arn. Must first authenticate with
+  OIDC or static AWS Keys stored as environment variables in CircleCI. 
 usage:
   version: 2.1
 

--- a/src/examples/configure_role_arn.yml
+++ b/src/examples/configure_role_arn.yml
@@ -1,6 +1,6 @@
-description: | 
+description: |
   Configure a new profile to assume a role defined by a role_arn. Must first authenticate with
-  OIDC or static AWS Keys stored as environment variables in CircleCI. 
+  OIDC or static AWS Keys stored as environment variables in CircleCI.
 usage:
   version: 2.1
 


### PR DESCRIPTION
This `PR` adds additional checks to the `integration-test-role-arn-setup` test. 

After it executes the `aws-cli/role_arn_setup` command, it logs into `aws ecr` using the profile that's been configured. 