### PR TITLE
Allow for `session_duration` env substitution

### DIFF
--- a/src/scripts/assume_role_with_web_identity.sh
+++ b/src/scripts/assume_role_with_web_identity.sh
@@ -3,7 +3,7 @@ AWS_CLI_STR_ROLE_SESSION_NAME="$(echo "${AWS_CLI_STR_ROLE_SESSION_NAME}" | circl
 AWS_CLI_STR_ROLE_ARN="$(echo "${AWS_CLI_STR_ROLE_ARN}" | circleci env subst)"
 AWS_CLI_STR_PROFILE_NAME="$(echo "${AWS_CLI_STR_PROFILE_NAME}" | circleci env subst)"
 AWS_CLI_STR_REGION="$(echo "${AWS_CLI_STR_REGION}" | circleci env subst)"
-
+AWS_CLI_INT_SESSION_DURATION="$(echo "${AWS_CLI_INT_SESSION_DURATION}" | circleci env subst)"
 
 # Replaces white spaces in role session name with dashes
 AWS_CLI_STR_ROLE_SESSION_NAME=$(echo "${AWS_CLI_STR_ROLE_SESSION_NAME}" | tr ' ' '-')


### PR DESCRIPTION
The other parameters in `assume_role_with_web_identity` allow for env substitution, but `session_duration` does not. This change simply adds env substitution in the same exact pattern as the others.

### Checklist
- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

This is needed so we can pass in an environment variable as the value for session duration. We have our own private orb that we're wrapping this command in and we're calculating the needed session_duration in a previous step and saving it to BASH_ENV, where we can then pass it in to `assume_role_with_web_identity`.

### Description
- add `circleci env subst` to `session_duration` parameter of `assume_role_with_web_identity` command.