### PR TITLE
feat: sanitize role session name

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -164,6 +164,22 @@ workflows:
                 name: Web Identity Test - Logging into ECR
                 command: aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin 122211685980.dkr.ecr.us-west-2.amazonaws.com
       - integration-test-install:
+          name: integration-test-web-identity-parameters
+          role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+          session_duration: "${TEST_SESSION_DURATION}"
+          role_session_name: "test-Sess1on Wi7h inv@lid-characters that's longer than 64 chars"
+          context: [CPE-OIDC]
+          executor: docker-base
+          post-steps:
+            - run:
+                name: Check Values of Expanded Variables
+                command: |
+                  if [ "${TEST_SESSION_DURATION}" -eq "900" ]; then
+                    exit 0
+                  else
+                    exit 1
+                  fi
+      - integration-test-install:
           name: integration-test-web-identity-with-profile
           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
           profile_name: "OIDC-Tester"

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -166,19 +166,9 @@ workflows:
       - integration-test-install:
           name: integration-test-web-identity-parameters
           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-          session_duration: "${TEST_SESSION_DURATION}"
-          role_session_name: "test-Sess1on Wi7h inv@lid-characters that's longer than 64 chars"
+          role_session_name: "test-Sess!on Wi7h inv^l!d-characters that's longer than 64 chars"
           context: [CPE-OIDC]
           executor: docker-base
-          post-steps:
-            - run:
-                name: Check Values of Expanded Variables
-                command: |
-                  if [ "${TEST_SESSION_DURATION}" -eq "900" ]; then
-                    exit 0
-                  else
-                    exit 1
-                  fi
       - integration-test-install:
           name: integration-test-web-identity-with-profile
           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST

--- a/src/scripts/assume_role_with_web_identity.sh
+++ b/src/scripts/assume_role_with_web_identity.sh
@@ -5,8 +5,11 @@ AWS_CLI_STR_PROFILE_NAME="$(echo "${AWS_CLI_STR_PROFILE_NAME}" | circleci env su
 AWS_CLI_STR_REGION="$(echo "${AWS_CLI_STR_REGION}" | circleci env subst)"
 
 
-# Replaces white spaces in role session name with dashes
-AWS_CLI_STR_ROLE_SESSION_NAME=$(echo "${AWS_CLI_STR_ROLE_SESSION_NAME}" | tr ' ' '-')
+# Sanitise role session name
+# Remove invalid characters
+AWS_CLI_STR_ROLE_SESSION_NAME=$(echo "${AWS_CLI_STR_ROLE_SESSION_NAME}" | tr -sC 'A-Za-z0-9=,.@_\-' '-')
+# Trim to 64 characters
+AWS_CLI_STR_ROLE_SESSION_NAME=$(echo "${AWS_CLI_STR_ROLE_SESSION_NAME}" | cut -c -64)
 if [ -z "${AWS_CLI_STR_ROLE_SESSION_NAME}" ]; then
     echo "Role session name is required"
     exit 1
@@ -43,7 +46,7 @@ touch "$temp_file"
 if [ -z "${AWS_ACCESS_KEY_ID}" ] || [ -z "${AWS_SECRET_ACCESS_KEY}" ] || [ -z "${AWS_SESSION_TOKEN}" ]; then
     echo "Failed to assume role";
     exit 1
-else 
+else
     {
         echo "export AWS_CLI_STR_ACCESS_KEY_ID=\"${AWS_ACCESS_KEY_ID}\""
         echo "export AWS_CLI_STR_SECRET_ACCESS_KEY=\"${AWS_SECRET_ACCESS_KEY}\""


### PR DESCRIPTION
The `role_session_name` parameter can only contain `64` characters and can only contain uppercase and lowercase letters, digits from 0-9, and the characters `=`,`,`,`.`, `@`, `_`, and `-`.

This pull request sanitizes the `role_session_name` parameter, ensuring that it's properly formatted so that the `assume_role_with_web_identity` command does not fail. It also adds testing for this parameter as well. 