### PR TITLE
fix: install curl on alpine linux

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -252,7 +252,7 @@ workflows:
 executors:
   terraform:
     docker:
-      - image: hashicorp/terraform:1.3.4
+      - image: hashicorp/terraform:1.4.1
   alpine:
     docker:
       - image: alpine:latest

--- a/src/scripts/linux/install.sh
+++ b/src/scripts/linux/install.sh
@@ -10,10 +10,8 @@ Install_AWS_CLI() {
     echo "Installing AWS CLI v2"
     cd /tmp || exit
     if [ "$SYS_ENV_PLATFORM" = "linux_alpine" ]; then
-        apk update
-        apk --no-cache add \
-            binutils \
-            curl
+        apk update && apk upgrade && apk add -U curl
+        apk --no-cache add binutils 
         apk --no-cache add libcurl
         apk --no-cache upgrade libcurl
         curl -L https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub


### PR DESCRIPTION
Some users are reporting failures with the `aws-cli/install` command on different versions of `Alpine Linux`. 

This `PR` fixes the issue by updating and upgrading `apk` before installing `curl`