### PR TITLE
fix: override installed windows

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -275,7 +275,7 @@ executors:
       image: ubuntu-2004:202101-01
   windows:
     machine:
-      image: windows-server-2019-vs2019:stable
+      image: windows-server-2019-vs2019:2023.04.1
     shell: bash.exe
     resource_class: windows.medium
 commands:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -115,120 +115,120 @@ workflows:
   test-deploy:
     jobs:
       # Testing region configuration
-      # - integration-test-install:
-      #     name: integration-test-configure-profile-region
-      #     role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-      #     profile_name: "OIDC-User"
-      #     context: [CPE-OIDC]
-      #     configure_default_region: false
-      #     region: us-west-2
-      #     executor: docker-base
-      #     post-steps:
-      #       - run:
-      #           name: Checking ~/.aws/config for profile region
-      #           command: |
-      #             if grep "\[profile OIDC-User\]" ~/.aws/config && grep "us-west-2" ~/.aws/config;then 
-      #               echo "Profile region properly configured"
-      #               exit 0
-      #             else
-      #               echo "Profile region not properly configured"
-      #               exit 1
-      #             fi
-      # - integration-test-install:
-      #     name: integration-test-configure-default-region
-      #     role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-      #     profile_name: "OIDC-User"
-      #     context: [CPE-OIDC]
-      #     configure_profile_region: false
-      #     region: us-west-1
-      #     executor: docker-base
-      #     post-steps:
-      #       - run:
-      #           name: Checking ~/.aws/config for default region
-      #           command: |
-      #             if grep "\[default\]" ~/.aws/config && grep "us-west-1" ~/.aws/config;then 
-      #               echo "Default region properly configured"
-      #               exit 0
-      #             else
-      #               echo "Default region not properly configured"
-      #               exit 1
-      #             fi
-      # # Testing OIDC
-      # - integration-test-install:
-      #     name: integration test web identity command with white spaces
-      #     role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-      #     context: [CPE-OIDC]
-      #     executor: docker-base
-      #     post-steps:
-      #       - run:
-      #           name: Web Identity Test - Logging into ECR
-      #           command: aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin 122211685980.dkr.ecr.us-west-2.amazonaws.com
-      # - integration-test-install:
-      #     name: integration-test-web-identity-parameters
-      #     role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-      #     session_duration: "${TEST_SESSION_DURATION}"
-      #     context: [CPE-OIDC]
-      #     executor: docker-base
-      #     role_session_name: "test-Sess!on Wi7h inv^l!d-characters that's longer than 64 chars"
-      #     post-steps:
-      #       - run:
-      #           name: Check Values of Expanded Variables
-      #           command: |
-      #             if [ "${TEST_SESSION_DURATION}" -eq "900" ]; then
-      #               exit 0
-      #             else
-      #               exit 1
-      #             fi
-      # - integration-test-install:
-      #     name: integration-test-web-identity-with-profile
-      #     role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-      #     profile_name: "OIDC-Tester"
-      #     context: [CPE-OIDC]
-      #     executor: docker-base
-      #     post-steps:
-      #       - run:
-      #           name: Web Identity Test - Logging into ECR
-      #           command: aws ecr get-login-password --region us-west-2 --profile "OIDC-Tester" | docker login --username AWS --password-stdin 122211685980.dkr.ecr.us-west-2.amazonaws.com
-      # # Testing executors that do not AWS CLI pre-installed
-      # - integration-test-install:
-      #     name: integration-test-install-<<matrix.executor>>
-      #     context: [CPE_ORBS_AWS]
-      #     matrix:
-      #       alias: test-install
-      #       parameters:
-      #         executor: ["docker-base", "macos", "alpine", "docker-nounset-shell", terraform ]
-      #     filters: *filters
-      #     post-steps:
-      #       - check_aws_version
-      # # Test installing specific versions on executors without AWS pre-installed
-      # - integration-test-install:
-      #     name: integration-test-install-version-<<matrix.executor>>
-      #     context: [CPE_ORBS_AWS]
-      #     matrix:
-      #       alias: test-install-version
-      #       parameters:
-      #         executor: ["docker-base", "macos", "alpine", "docker-nounset-shell" ]
-      #     version: "2.1.10"
-      #     filters: *filters
-      #     post-steps:
-      #       - check_aws_version:
-      #           version: "2.1.10"
-      # # Test overriding existing version of AWS pre-installed
-      # - integration-test-install:
-      #     name: integration-test-install-override-version-<<matrix.executor>>
-      #     context: [CPE_ORBS_AWS]
-      #     matrix:
-      #       alias: test-install-override-version
-      #       parameters:
-      #         executor: ["linuxvm", "windows", "arm"]
-      #     version: "2.1.10"
-      #     install_dir: "/usr/local/aws-cli"
-      #     binary_dir: ""
-      #     override_installed: false
-      #     filters: *filters
-      #     post-steps:
-      #       - check_aws_version:
-      #           version: "2.1.10"
+      - integration-test-install:
+          name: integration-test-configure-profile-region
+          role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+          profile_name: "OIDC-User"
+          context: [CPE-OIDC]
+          configure_default_region: false
+          region: us-west-2
+          executor: docker-base
+          post-steps:
+            - run:
+                name: Checking ~/.aws/config for profile region
+                command: |
+                  if grep "\[profile OIDC-User\]" ~/.aws/config && grep "us-west-2" ~/.aws/config;then 
+                    echo "Profile region properly configured"
+                    exit 0
+                  else
+                    echo "Profile region not properly configured"
+                    exit 1
+                  fi
+      - integration-test-install:
+          name: integration-test-configure-default-region
+          role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+          profile_name: "OIDC-User"
+          context: [CPE-OIDC]
+          configure_profile_region: false
+          region: us-west-1
+          executor: docker-base
+          post-steps:
+            - run:
+                name: Checking ~/.aws/config for default region
+                command: |
+                  if grep "\[default\]" ~/.aws/config && grep "us-west-1" ~/.aws/config;then 
+                    echo "Default region properly configured"
+                    exit 0
+                  else
+                    echo "Default region not properly configured"
+                    exit 1
+                  fi
+      # Testing OIDC
+      - integration-test-install:
+          name: integration test web identity command with white spaces
+          role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+          context: [CPE-OIDC]
+          executor: docker-base
+          post-steps:
+            - run:
+                name: Web Identity Test - Logging into ECR
+                command: aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin 122211685980.dkr.ecr.us-west-2.amazonaws.com
+      - integration-test-install:
+          name: integration-test-web-identity-parameters
+          role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+          session_duration: "${TEST_SESSION_DURATION}"
+          context: [CPE-OIDC]
+          executor: docker-base
+          role_session_name: "test-Sess!on Wi7h inv^l!d-characters that's longer than 64 chars"
+          post-steps:
+            - run:
+                name: Check Values of Expanded Variables
+                command: |
+                  if [ "${TEST_SESSION_DURATION}" -eq "900" ]; then
+                    exit 0
+                  else
+                    exit 1
+                  fi
+      - integration-test-install:
+          name: integration-test-web-identity-with-profile
+          role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+          profile_name: "OIDC-Tester"
+          context: [CPE-OIDC]
+          executor: docker-base
+          post-steps:
+            - run:
+                name: Web Identity Test - Logging into ECR
+                command: aws ecr get-login-password --region us-west-2 --profile "OIDC-Tester" | docker login --username AWS --password-stdin 122211685980.dkr.ecr.us-west-2.amazonaws.com
+      # Testing executors that do not AWS CLI pre-installed
+      - integration-test-install:
+          name: integration-test-install-<<matrix.executor>>
+          context: [CPE_ORBS_AWS]
+          matrix:
+            alias: test-install
+            parameters:
+              executor: ["docker-base", "macos", "alpine", "docker-nounset-shell", terraform ]
+          filters: *filters
+          post-steps:
+            - check_aws_version
+      # Test installing specific versions on executors without AWS pre-installed
+      - integration-test-install:
+          name: integration-test-install-version-<<matrix.executor>>
+          context: [CPE_ORBS_AWS]
+          matrix:
+            alias: test-install-version
+            parameters:
+              executor: ["docker-base", "macos", "alpine", "docker-nounset-shell" ]
+          version: "2.1.10"
+          filters: *filters
+          post-steps:
+            - check_aws_version:
+                version: "2.1.10"
+      # Test overriding existing version of AWS pre-installed
+      - integration-test-install:
+          name: integration-test-install-override-version-<<matrix.executor>>
+          context: [CPE_ORBS_AWS]
+          matrix:
+            alias: test-install-override-version
+            parameters:
+              executor: ["linuxvm", "windows", "arm"]
+          version: "2.1.10"
+          install_dir: "/usr/local/aws-cli"
+          binary_dir: ""
+          override_installed: false
+          filters: *filters
+          post-steps:
+            - check_aws_version:
+                version: "2.1.10"
       - integration-test-install:
           name: integration-test-install-override-version-with-latest-<<matrix.executor>>
           context: [CPE_ORBS_AWS]
@@ -240,26 +240,26 @@ workflows:
           binary_dir: ""
           override_installed: true
           filters: *filters
-      # - integration-test-role-arn-setup:
-      #     name: integration-test-role-arn-config
-      #     source_profile: default
-      #     profile_name: CircleCI-Tester
-      #     role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-      #     context: [CPE_ORBS_AWS]
-      #     post-steps:
-      #       - run:
-      #             name: Logging into ECR with new profile
-      #             command: aws ecr get-login-password --region us-west-2 --profile "CircleCI-Tester" | docker login --username AWS --password-stdin 122211685980.dkr.ecr.us-west-2.amazonaws.com
-      # - orb-tools/pack:
-      #     filters: *release-filters
-      # - orb-tools/publish:
-      #     orb_name: circleci/aws-cli
-      #     vcs_type: << pipeline.project.type >>
-      #     pub_type: production
-      #     enable_pr_comment: true
-      #     context: orb-publisher
-      #     requires: [orb-tools/pack, test-install, test-install-version, test-install-override-version, integration-test-web-identity-with-profile, integration test web identity command with white spaces,integration-test-role-arn-config, test-install-override-version-with-latest]
-      #     filters: *release-filters
+      - integration-test-role-arn-setup:
+          name: integration-test-role-arn-config
+          source_profile: default
+          profile_name: CircleCI-Tester
+          role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+          context: [CPE_ORBS_AWS]
+          post-steps:
+            - run:
+                  name: Logging into ECR with new profile
+                  command: aws ecr get-login-password --region us-west-2 --profile "CircleCI-Tester" | docker login --username AWS --password-stdin 122211685980.dkr.ecr.us-west-2.amazonaws.com
+      - orb-tools/pack:
+          filters: *release-filters
+      - orb-tools/publish:
+          orb_name: circleci/aws-cli
+          vcs_type: << pipeline.project.type >>
+          pub_type: production
+          enable_pr_comment: true
+          context: orb-publisher
+          requires: [orb-tools/pack, test-install, test-install-version, test-install-override-version, integration-test-web-identity-with-profile, integration test web identity command with white spaces,integration-test-role-arn-config, test-install-override-version-with-latest]
+          filters: *release-filters
 executors:
   terraform:
     docker:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -115,140 +115,151 @@ workflows:
   test-deploy:
     jobs:
       # Testing region configuration
+      # - integration-test-install:
+      #     name: integration-test-configure-profile-region
+      #     role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+      #     profile_name: "OIDC-User"
+      #     context: [CPE-OIDC]
+      #     configure_default_region: false
+      #     region: us-west-2
+      #     executor: docker-base
+      #     post-steps:
+      #       - run:
+      #           name: Checking ~/.aws/config for profile region
+      #           command: |
+      #             if grep "\[profile OIDC-User\]" ~/.aws/config && grep "us-west-2" ~/.aws/config;then 
+      #               echo "Profile region properly configured"
+      #               exit 0
+      #             else
+      #               echo "Profile region not properly configured"
+      #               exit 1
+      #             fi
+      # - integration-test-install:
+      #     name: integration-test-configure-default-region
+      #     role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+      #     profile_name: "OIDC-User"
+      #     context: [CPE-OIDC]
+      #     configure_profile_region: false
+      #     region: us-west-1
+      #     executor: docker-base
+      #     post-steps:
+      #       - run:
+      #           name: Checking ~/.aws/config for default region
+      #           command: |
+      #             if grep "\[default\]" ~/.aws/config && grep "us-west-1" ~/.aws/config;then 
+      #               echo "Default region properly configured"
+      #               exit 0
+      #             else
+      #               echo "Default region not properly configured"
+      #               exit 1
+      #             fi
+      # # Testing OIDC
+      # - integration-test-install:
+      #     name: integration test web identity command with white spaces
+      #     role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+      #     context: [CPE-OIDC]
+      #     executor: docker-base
+      #     post-steps:
+      #       - run:
+      #           name: Web Identity Test - Logging into ECR
+      #           command: aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin 122211685980.dkr.ecr.us-west-2.amazonaws.com
+      # - integration-test-install:
+      #     name: integration-test-web-identity-parameters
+      #     role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+      #     session_duration: "${TEST_SESSION_DURATION}"
+      #     context: [CPE-OIDC]
+      #     executor: docker-base
+      #     role_session_name: "test-Sess!on Wi7h inv^l!d-characters that's longer than 64 chars"
+      #     post-steps:
+      #       - run:
+      #           name: Check Values of Expanded Variables
+      #           command: |
+      #             if [ "${TEST_SESSION_DURATION}" -eq "900" ]; then
+      #               exit 0
+      #             else
+      #               exit 1
+      #             fi
+      # - integration-test-install:
+      #     name: integration-test-web-identity-with-profile
+      #     role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+      #     profile_name: "OIDC-Tester"
+      #     context: [CPE-OIDC]
+      #     executor: docker-base
+      #     post-steps:
+      #       - run:
+      #           name: Web Identity Test - Logging into ECR
+      #           command: aws ecr get-login-password --region us-west-2 --profile "OIDC-Tester" | docker login --username AWS --password-stdin 122211685980.dkr.ecr.us-west-2.amazonaws.com
+      # # Testing executors that do not AWS CLI pre-installed
+      # - integration-test-install:
+      #     name: integration-test-install-<<matrix.executor>>
+      #     context: [CPE_ORBS_AWS]
+      #     matrix:
+      #       alias: test-install
+      #       parameters:
+      #         executor: ["docker-base", "macos", "alpine", "docker-nounset-shell", terraform ]
+      #     filters: *filters
+      #     post-steps:
+      #       - check_aws_version
+      # # Test installing specific versions on executors without AWS pre-installed
+      # - integration-test-install:
+      #     name: integration-test-install-version-<<matrix.executor>>
+      #     context: [CPE_ORBS_AWS]
+      #     matrix:
+      #       alias: test-install-version
+      #       parameters:
+      #         executor: ["docker-base", "macos", "alpine", "docker-nounset-shell" ]
+      #     version: "2.1.10"
+      #     filters: *filters
+      #     post-steps:
+      #       - check_aws_version:
+      #           version: "2.1.10"
+      # # Test overriding existing version of AWS pre-installed
+      # - integration-test-install:
+      #     name: integration-test-install-override-version-<<matrix.executor>>
+      #     context: [CPE_ORBS_AWS]
+      #     matrix:
+      #       alias: test-install-override-version
+      #       parameters:
+      #         executor: ["linuxvm", "windows", "arm"]
+      #     version: "2.1.10"
+      #     install_dir: "/usr/local/aws-cli"
+      #     binary_dir: ""
+      #     override_installed: false
+      #     filters: *filters
+      #     post-steps:
+      #       - check_aws_version:
+      #           version: "2.1.10"
       - integration-test-install:
-          name: integration-test-configure-profile-region
-          role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-          profile_name: "OIDC-User"
-          context: [CPE-OIDC]
-          configure_default_region: false
-          region: us-west-2
-          executor: docker-base
-          post-steps:
-            - run:
-                name: Checking ~/.aws/config for profile region
-                command: |
-                  if grep "\[profile OIDC-User\]" ~/.aws/config && grep "us-west-2" ~/.aws/config;then 
-                    echo "Profile region properly configured"
-                    exit 0
-                  else
-                    echo "Profile region not properly configured"
-                    exit 1
-                  fi
-      - integration-test-install:
-          name: integration-test-configure-default-region
-          role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-          profile_name: "OIDC-User"
-          context: [CPE-OIDC]
-          configure_profile_region: false
-          region: us-west-1
-          executor: docker-base
-          post-steps:
-            - run:
-                name: Checking ~/.aws/config for default region
-                command: |
-                  if grep "\[default\]" ~/.aws/config && grep "us-west-1" ~/.aws/config;then 
-                    echo "Default region properly configured"
-                    exit 0
-                  else
-                    echo "Default region not properly configured"
-                    exit 1
-                  fi
-      # Testing OIDC
-      - integration-test-install:
-          name: integration test web identity command with white spaces
-          role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-          context: [CPE-OIDC]
-          executor: docker-base
-          post-steps:
-            - run:
-                name: Web Identity Test - Logging into ECR
-                command: aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin 122211685980.dkr.ecr.us-west-2.amazonaws.com
-      - integration-test-install:
-          name: integration-test-web-identity-parameters
-          role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-          session_duration: "${TEST_SESSION_DURATION}"
-          context: [CPE-OIDC]
-          executor: docker-base
-          role_session_name: "test-Sess!on Wi7h inv^l!d-characters that's longer than 64 chars"
-          post-steps:
-            - run:
-                name: Check Values of Expanded Variables
-                command: |
-                  if [ "${TEST_SESSION_DURATION}" -eq "900" ]; then
-                    exit 0
-                  else
-                    exit 1
-                  fi
-      - integration-test-install:
-          name: integration-test-web-identity-with-profile
-          role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-          profile_name: "OIDC-Tester"
-          context: [CPE-OIDC]
-          executor: docker-base
-          post-steps:
-            - run:
-                name: Web Identity Test - Logging into ECR
-                command: aws ecr get-login-password --region us-west-2 --profile "OIDC-Tester" | docker login --username AWS --password-stdin 122211685980.dkr.ecr.us-west-2.amazonaws.com
-      # Testing executors that do not AWS CLI pre-installed
-      - integration-test-install:
-          name: integration-test-install-<<matrix.executor>>
+          name: integration-test-install-override-version-with-latest-<<matrix.executor>>
           context: [CPE_ORBS_AWS]
           matrix:
-            alias: test-install
-            parameters:
-              executor: ["docker-base", "macos", "alpine", "docker-nounset-shell", terraform ]
-          filters: *filters
-          post-steps:
-            - check_aws_version
-      # Test installing specific versions on executors without AWS pre-installed
-      - integration-test-install:
-          name: integration-test-install-version-<<matrix.executor>>
-          context: [CPE_ORBS_AWS]
-          matrix:
-            alias: test-install-version
-            parameters:
-              executor: ["docker-base", "macos", "alpine", "docker-nounset-shell" ]
-          version: "2.1.10"
-          filters: *filters
-          post-steps:
-            - check_aws_version:
-                version: "2.1.10"
-      # Test overriding existing version of AWS pre-installed
-      - integration-test-install:
-          name: integration-test-install-override-version-<<matrix.executor>>
-          context: [CPE_ORBS_AWS]
-          matrix:
-            alias: test-install-override-version
+            alias: test-install-override-version-with-latest
             parameters:
               executor: ["linuxvm", "windows", "arm"]
-          version: "2.1.10"
           install_dir: "/usr/local/aws-cli"
           binary_dir: ""
-          override_installed: false
+          override_installed: true
           filters: *filters
-          post-steps:
-            - check_aws_version:
-                version: "2.1.10"
-      - integration-test-role-arn-setup:
-          name: integration-test-role-arn-config
-          source_profile: default
-          profile_name: CircleCI-Tester
-          role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-          context: [CPE_ORBS_AWS]
-          post-steps:
-            - run:
-                  name: Logging into ECR with new profile
-                  command: aws ecr get-login-password --region us-west-2 --profile "CircleCI-Tester" | docker login --username AWS --password-stdin 122211685980.dkr.ecr.us-west-2.amazonaws.com
-      - orb-tools/pack:
-          filters: *release-filters
-      - orb-tools/publish:
-          orb_name: circleci/aws-cli
-          vcs_type: << pipeline.project.type >>
-          pub_type: production
-          enable_pr_comment: true
-          context: orb-publisher
-          requires: [orb-tools/pack, test-install, test-install-version, test-install-override-version, integration-test-web-identity-with-profile, integration test web identity command with white spaces,integration-test-role-arn-config]
-          filters: *release-filters
+      # - integration-test-role-arn-setup:
+      #     name: integration-test-role-arn-config
+      #     source_profile: default
+      #     profile_name: CircleCI-Tester
+      #     role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+      #     context: [CPE_ORBS_AWS]
+      #     post-steps:
+      #       - run:
+      #             name: Logging into ECR with new profile
+      #             command: aws ecr get-login-password --region us-west-2 --profile "CircleCI-Tester" | docker login --username AWS --password-stdin 122211685980.dkr.ecr.us-west-2.amazonaws.com
+      # - orb-tools/pack:
+      #     filters: *release-filters
+      # - orb-tools/publish:
+      #     orb_name: circleci/aws-cli
+      #     vcs_type: << pipeline.project.type >>
+      #     pub_type: production
+      #     enable_pr_comment: true
+      #     context: orb-publisher
+      #     requires: [orb-tools/pack, test-install, test-install-version, test-install-override-version, integration-test-web-identity-with-profile, integration test web identity command with white spaces,integration-test-role-arn-config, test-install-override-version-with-latest]
+      #     filters: *release-filters
 executors:
   terraform:
     docker:

--- a/src/scripts/windows/install.sh
+++ b/src/scripts/windows/install.sh
@@ -16,7 +16,7 @@ Install_AWS_CLI(){
     
     choco install awscli --version="$version"
     echo "Installing AWS CLI version $version"
-    if echo "$1" | grep "2."; then
+    if echo "$1" | grep -e "2." -e "latest"; then
         echo "export PATH=\"\${PATH}:/c/Program Files/Amazon/AWSCLIV2\"" >> "$BASH_ENV"
     else
         echo "export PATH=\"\${PATH}:/c/Program Files/Amazon/AWSCLI/bin\"" >>"$BASH_ENV"
@@ -28,5 +28,5 @@ Uninstall_AWS_CLI() {
         echo "Chocolatey is required to uninstall AWS"
         exit 1
     fi
-    choco uninstall awscli
+    choco uninstall awscli   
 }


### PR DESCRIPTION
Currently in the `aws-cli/install` command, when the `override_installed` parameter is set to `true` without a specified `version` in `windows`, the `latest` version of the `aws-cli` is installed. However, users are getting the following error: 

```
bash: aws: command not found
```

 The `PATH` is not set for the latest version because the script checks for only checks for `2.` in the version string but not `latest` as well. 

This pull request add additional validation so that the correct `PATH` is set when the version string is equal to `latest`. 