### PR TITLE
fix: edit grep

### DIFF
--- a/src/scripts/windows/install.sh
+++ b/src/scripts/windows/install.sh
@@ -16,7 +16,7 @@ Install_AWS_CLI(){
     
     choco install awscli --version="$version"
     echo "Installing AWS CLI version $version"
-    if echo "$1" | grep -e "2." -e "latest"; then
+    if echo "$1" | grep -e "^2\." -e "latest"; then
         echo "export PATH=\"\${PATH}:/c/Program Files/Amazon/AWSCLIV2\"" >> "$BASH_ENV"
     else
         echo "export PATH=\"\${PATH}:/c/Program Files/Amazon/AWSCLI/bin\"" >>"$BASH_ENV"


### PR DESCRIPTION
Currently, the `grep` statement in the `windows` install script checks for `2.`, which is intended to check for version `2` of the `aws cli`.  However, the install fails because any version string containing `2.` like `1.2.3` validate the `grep` statement. 

This `PR` edits the statement to check for `2.` in the first two characters of the version string. 