### PR TITLE
refactor: skip installation if specified version is installed

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -232,10 +232,7 @@ workflows:
       - integration-test-install:
           name: integration-test-skip-install-matched-version
           context: [CPE_ORBS_AWS]
-          matrix:
-            alias: test-install-override-version
-            parameters:
-              executor: [ "arm" ]
+          executor: [ "arm" ]
           version: "2.1.21"
           install_dir: "/usr/local/aws-cli"
           binary_dir: ""

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -114,152 +114,173 @@ jobs:
 workflows:
   test-deploy:
     jobs:
-      # Testing region configuration
+      # # Testing region configuration
+      # - integration-test-install:
+      #     name: integration-test-configure-profile-region
+      #     role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+      #     profile_name: "OIDC-User"
+      #     context: [CPE-OIDC]
+      #     configure_default_region: false
+      #     region: us-west-2
+      #     executor: docker-base
+      #     post-steps:
+      #       - run:
+      #           name: Checking ~/.aws/config for profile region
+      #           command: |
+      #             if grep "\[profile OIDC-User\]" ~/.aws/config && grep "us-west-2" ~/.aws/config;then 
+      #               echo "Profile region properly configured"
+      #               exit 0
+      #             else
+      #               echo "Profile region not properly configured"
+      #               exit 1
+      #             fi
+      # - integration-test-install:
+      #     name: integration-test-configure-default-region
+      #     role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+      #     profile_name: "OIDC-User"
+      #     context: [CPE-OIDC]
+      #     configure_profile_region: false
+      #     region: us-west-1
+      #     executor: docker-base
+      #     post-steps:
+      #       - run:
+      #           name: Checking ~/.aws/config for default region
+      #           command: |
+      #             if grep "\[default\]" ~/.aws/config && grep "us-west-1" ~/.aws/config;then 
+      #               echo "Default region properly configured"
+      #               exit 0
+      #             else
+      #               echo "Default region not properly configured"
+      #               exit 1
+      #             fi
+      # # Testing OIDC
+      # - integration-test-install:
+      #     name: integration test web identity command with white spaces
+      #     role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+      #     context: [CPE-OIDC]
+      #     executor: docker-base
+      #     post-steps:
+      #       - run:
+      #           name: Web Identity Test - Logging into ECR
+      #           command: aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin 122211685980.dkr.ecr.us-west-2.amazonaws.com
+      # - integration-test-install:
+      #     name: integration-test-web-identity-parameters
+      #     role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+      #     session_duration: "${TEST_SESSION_DURATION}"
+      #     context: [CPE-OIDC]
+      #     executor: docker-base
+      #     role_session_name: "test-Sess!on Wi7h inv^l!d-characters that's longer than 64 chars"
+      #     post-steps:
+      #       - run:
+      #           name: Check Values of Expanded Variables
+      #           command: |
+      #             if [ "${TEST_SESSION_DURATION}" -eq "900" ]; then
+      #               exit 0
+      #             else
+      #               exit 1
+      #             fi
+      # - integration-test-install:
+      #     name: integration-test-web-identity-with-profile
+      #     role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+      #     profile_name: "OIDC-Tester"
+      #     context: [CPE-OIDC]
+      #     executor: docker-base
+      #     post-steps:
+      #       - run:
+      #           name: Web Identity Test - Logging into ECR
+      #           command: aws ecr get-login-password --region us-west-2 --profile "OIDC-Tester" | docker login --username AWS --password-stdin 122211685980.dkr.ecr.us-west-2.amazonaws.com
+      # # Testing executors that do not AWS CLI pre-installed
+      # - integration-test-install:
+      #     name: integration-test-install-<<matrix.executor>>
+      #     context: [CPE_ORBS_AWS]
+      #     matrix:
+      #       alias: test-install
+      #       parameters:
+      #         executor: ["docker-base", "macos", "alpine", "docker-nounset-shell", terraform ]
+      #     filters: *filters
+      #     post-steps:
+      #       - check_aws_version
+      # # Test installing specific versions on executors without AWS pre-installed
+      # - integration-test-install:
+      #     name: integration-test-install-version-<<matrix.executor>>
+      #     context: [CPE_ORBS_AWS]
+      #     matrix:
+      #       alias: test-install-version
+      #       parameters:
+      #         executor: ["docker-base", "macos", "alpine", "docker-nounset-shell" ]
+      #     version: "2.1.10"
+      #     filters: *filters
+      #     post-steps:
+      #       - check_aws_version:
+      #           version: "2.1.10"
+      # # Test overriding existing version of AWS pre-installed
+      # - integration-test-install:
+      #     name: integration-test-install-override-version-<<matrix.executor>>
+      #     context: [CPE_ORBS_AWS]
+      #     matrix:
+      #       alias: test-install-override-version
+      #       parameters:
+      #         executor: ["linuxvm", "windows", "arm"]
+      #     version: "2.1.10"
+      #     install_dir: "/usr/local/aws-cli"
+      #     binary_dir: ""
+      #     override_installed: false
+      #     filters: *filters
+      #     post-steps:
+      #       - check_aws_version:
+      #           version: "2.1.10"
       - integration-test-install:
-          name: integration-test-configure-profile-region
-          role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-          profile_name: "OIDC-User"
-          context: [CPE-OIDC]
-          configure_default_region: false
-          region: us-west-2
-          executor: docker-base
-          post-steps:
-            - run:
-                name: Checking ~/.aws/config for profile region
-                command: |
-                  if grep "\[profile OIDC-User\]" ~/.aws/config && grep "us-west-2" ~/.aws/config;then 
-                    echo "Profile region properly configured"
-                    exit 0
-                  else
-                    echo "Profile region not properly configured"
-                    exit 1
-                  fi
-      - integration-test-install:
-          name: integration-test-configure-default-region
-          role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-          profile_name: "OIDC-User"
-          context: [CPE-OIDC]
-          configure_profile_region: false
-          region: us-west-1
-          executor: docker-base
-          post-steps:
-            - run:
-                name: Checking ~/.aws/config for default region
-                command: |
-                  if grep "\[default\]" ~/.aws/config && grep "us-west-1" ~/.aws/config;then 
-                    echo "Default region properly configured"
-                    exit 0
-                  else
-                    echo "Default region not properly configured"
-                    exit 1
-                  fi
-      # Testing OIDC
-      - integration-test-install:
-          name: integration test web identity command with white spaces
-          role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-          context: [CPE-OIDC]
-          executor: docker-base
-          post-steps:
-            - run:
-                name: Web Identity Test - Logging into ECR
-                command: aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin 122211685980.dkr.ecr.us-west-2.amazonaws.com
-      - integration-test-install:
-          name: integration-test-web-identity-parameters
-          role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-          session_duration: "${TEST_SESSION_DURATION}"
-          context: [CPE-OIDC]
-          executor: docker-base
-          role_session_name: "test-Sess!on Wi7h inv^l!d-characters that's longer than 64 chars"
-          post-steps:
-            - run:
-                name: Check Values of Expanded Variables
-                command: |
-                  if [ "${TEST_SESSION_DURATION}" -eq "900" ]; then
-                    exit 0
-                  else
-                    exit 1
-                  fi
-      - integration-test-install:
-          name: integration-test-web-identity-with-profile
-          role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-          profile_name: "OIDC-Tester"
-          context: [CPE-OIDC]
-          executor: docker-base
-          post-steps:
-            - run:
-                name: Web Identity Test - Logging into ECR
-                command: aws ecr get-login-password --region us-west-2 --profile "OIDC-Tester" | docker login --username AWS --password-stdin 122211685980.dkr.ecr.us-west-2.amazonaws.com
-      # Testing executors that do not AWS CLI pre-installed
-      - integration-test-install:
-          name: integration-test-install-<<matrix.executor>>
-          context: [CPE_ORBS_AWS]
-          matrix:
-            alias: test-install
-            parameters:
-              executor: ["docker-base", "macos", "alpine", "docker-nounset-shell", terraform ]
-          filters: *filters
-          post-steps:
-            - check_aws_version
-      # Test installing specific versions on executors without AWS pre-installed
-      - integration-test-install:
-          name: integration-test-install-version-<<matrix.executor>>
-          context: [CPE_ORBS_AWS]
-          matrix:
-            alias: test-install-version
-            parameters:
-              executor: ["docker-base", "macos", "alpine", "docker-nounset-shell" ]
-          version: "2.1.10"
-          filters: *filters
-          post-steps:
-            - check_aws_version:
-                version: "2.1.10"
-      # Test overriding existing version of AWS pre-installed
-      - integration-test-install:
-          name: integration-test-install-override-version-<<matrix.executor>>
+          name: integration-test-skip-install-matched-version
           context: [CPE_ORBS_AWS]
           matrix:
             alias: test-install-override-version
             parameters:
-              executor: ["linuxvm", "windows", "arm"]
+              executor: [ "arm" ]
           version: "2.1.10"
           install_dir: "/usr/local/aws-cli"
           binary_dir: ""
           override_installed: false
           filters: *filters
+          pre-steps:
+            - run:
+                command: |
+                  set -x
+                  aws --version
+                  set +x
           post-steps:
             - check_aws_version:
                 version: "2.1.10"
-      - integration-test-install:
-          name: integration-test-install-override-version-with-latest-<<matrix.executor>>
-          context: [CPE_ORBS_AWS]
-          matrix:
-            alias: test-install-override-version-with-latest
-            parameters:
-              executor: ["linuxvm", "windows", "arm"]
-          install_dir: "/usr/local/aws-cli"
-          binary_dir: ""
-          override_installed: true
-          filters: *filters
-      - integration-test-role-arn-setup:
-          name: integration-test-role-arn-config
-          source_profile: default
-          profile_name: CircleCI-Tester
-          role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-          context: [CPE_ORBS_AWS]
-          post-steps:
-            - run:
-                  name: Logging into ECR with new profile
-                  command: aws ecr get-login-password --region us-west-2 --profile "CircleCI-Tester" | docker login --username AWS --password-stdin 122211685980.dkr.ecr.us-west-2.amazonaws.com
-      - orb-tools/pack:
-          filters: *release-filters
-      - orb-tools/publish:
-          orb_name: circleci/aws-cli
-          vcs_type: << pipeline.project.type >>
-          pub_type: production
-          enable_pr_comment: true
-          context: orb-publisher
-          requires: [orb-tools/pack, test-install, test-install-version, test-install-override-version, integration-test-web-identity-with-profile, integration test web identity command with white spaces,integration-test-role-arn-config, test-install-override-version-with-latest]
-          filters: *release-filters
+      # - integration-test-install:
+      #     name: integration-test-install-override-version-with-latest-<<matrix.executor>>
+      #     context: [CPE_ORBS_AWS]
+      #     matrix:
+      #       alias: test-install-override-version-with-latest
+      #       parameters:
+      #         executor: ["linuxvm", "windows", "arm"]
+      #     install_dir: "/usr/local/aws-cli"
+      #     binary_dir: ""
+      #     override_installed: true
+      #     filters: *filters
+      # - integration-test-role-arn-setup:
+      #     name: integration-test-role-arn-config
+      #     source_profile: default
+      #     profile_name: CircleCI-Tester
+      #     role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+      #     context: [CPE_ORBS_AWS]
+      #     post-steps:
+      #       - run:
+      #             name: Logging into ECR with new profile
+      #             command: aws ecr get-login-password --region us-west-2 --profile "CircleCI-Tester" | docker login --username AWS --password-stdin 122211685980.dkr.ecr.us-west-2.amazonaws.com
+      # - orb-tools/pack:
+      #     filters: *release-filters
+      # - orb-tools/publish:
+      #     orb_name: circleci/aws-cli
+      #     vcs_type: << pipeline.project.type >>
+      #     pub_type: production
+      #     enable_pr_comment: true
+      #     context: orb-publisher
+      #     requires: [orb-tools/pack, test-install, test-install-version, test-install-override-version, integration-test-web-identity-with-profile, integration test web identity command with white spaces,integration-test-role-arn-config, test-install-override-version-with-latest]
+      #     filters: *release-filters
 executors:
   terraform:
     docker:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -232,7 +232,7 @@ workflows:
       - integration-test-install:
           name: integration-test-skip-install-matched-version
           context: [CPE_ORBS_AWS]
-          executor: [ "arm" ]
+          executor: arm
           version: "2.1.21"
           install_dir: "/usr/local/aws-cli"
           binary_dir: ""

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -114,121 +114,121 @@ jobs:
 workflows:
   test-deploy:
     jobs:
-      # # Testing region configuration
-      # - integration-test-install:
-      #     name: integration-test-configure-profile-region
-      #     role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-      #     profile_name: "OIDC-User"
-      #     context: [CPE-OIDC]
-      #     configure_default_region: false
-      #     region: us-west-2
-      #     executor: docker-base
-      #     post-steps:
-      #       - run:
-      #           name: Checking ~/.aws/config for profile region
-      #           command: |
-      #             if grep "\[profile OIDC-User\]" ~/.aws/config && grep "us-west-2" ~/.aws/config;then 
-      #               echo "Profile region properly configured"
-      #               exit 0
-      #             else
-      #               echo "Profile region not properly configured"
-      #               exit 1
-      #             fi
-      # - integration-test-install:
-      #     name: integration-test-configure-default-region
-      #     role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-      #     profile_name: "OIDC-User"
-      #     context: [CPE-OIDC]
-      #     configure_profile_region: false
-      #     region: us-west-1
-      #     executor: docker-base
-      #     post-steps:
-      #       - run:
-      #           name: Checking ~/.aws/config for default region
-      #           command: |
-      #             if grep "\[default\]" ~/.aws/config && grep "us-west-1" ~/.aws/config;then 
-      #               echo "Default region properly configured"
-      #               exit 0
-      #             else
-      #               echo "Default region not properly configured"
-      #               exit 1
-      #             fi
-      # # Testing OIDC
-      # - integration-test-install:
-      #     name: integration test web identity command with white spaces
-      #     role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-      #     context: [CPE-OIDC]
-      #     executor: docker-base
-      #     post-steps:
-      #       - run:
-      #           name: Web Identity Test - Logging into ECR
-      #           command: aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin 122211685980.dkr.ecr.us-west-2.amazonaws.com
-      # - integration-test-install:
-      #     name: integration-test-web-identity-parameters
-      #     role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-      #     session_duration: "${TEST_SESSION_DURATION}"
-      #     context: [CPE-OIDC]
-      #     executor: docker-base
-      #     role_session_name: "test-Sess!on Wi7h inv^l!d-characters that's longer than 64 chars"
-      #     post-steps:
-      #       - run:
-      #           name: Check Values of Expanded Variables
-      #           command: |
-      #             if [ "${TEST_SESSION_DURATION}" -eq "900" ]; then
-      #               exit 0
-      #             else
-      #               exit 1
-      #             fi
-      # - integration-test-install:
-      #     name: integration-test-web-identity-with-profile
-      #     role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-      #     profile_name: "OIDC-Tester"
-      #     context: [CPE-OIDC]
-      #     executor: docker-base
-      #     post-steps:
-      #       - run:
-      #           name: Web Identity Test - Logging into ECR
-      #           command: aws ecr get-login-password --region us-west-2 --profile "OIDC-Tester" | docker login --username AWS --password-stdin 122211685980.dkr.ecr.us-west-2.amazonaws.com
-      # # Testing executors that do not AWS CLI pre-installed
-      # - integration-test-install:
-      #     name: integration-test-install-<<matrix.executor>>
-      #     context: [CPE_ORBS_AWS]
-      #     matrix:
-      #       alias: test-install
-      #       parameters:
-      #         executor: ["docker-base", "macos", "alpine", "docker-nounset-shell", terraform ]
-      #     filters: *filters
-      #     post-steps:
-      #       - check_aws_version
-      # # Test installing specific versions on executors without AWS pre-installed
-      # - integration-test-install:
-      #     name: integration-test-install-version-<<matrix.executor>>
-      #     context: [CPE_ORBS_AWS]
-      #     matrix:
-      #       alias: test-install-version
-      #       parameters:
-      #         executor: ["docker-base", "macos", "alpine", "docker-nounset-shell" ]
-      #     version: "2.1.10"
-      #     filters: *filters
-      #     post-steps:
-      #       - check_aws_version:
-      #           version: "2.1.10"
-      # # Test overriding existing version of AWS pre-installed
-      # - integration-test-install:
-      #     name: integration-test-install-override-version-<<matrix.executor>>
-      #     context: [CPE_ORBS_AWS]
-      #     matrix:
-      #       alias: test-install-override-version
-      #       parameters:
-      #         executor: ["linuxvm", "windows", "arm"]
-      #     version: "2.1.10"
-      #     install_dir: "/usr/local/aws-cli"
-      #     binary_dir: ""
-      #     override_installed: false
-      #     filters: *filters
-      #     post-steps:
-      #       - check_aws_version:
-      #           version: "2.1.10"
+      # Testing region configuration
+      - integration-test-install:
+          name: integration-test-configure-profile-region
+          role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+          profile_name: "OIDC-User"
+          context: [CPE-OIDC]
+          configure_default_region: false
+          region: us-west-2
+          executor: docker-base
+          post-steps:
+            - run:
+                name: Checking ~/.aws/config for profile region
+                command: |
+                  if grep "\[profile OIDC-User\]" ~/.aws/config && grep "us-west-2" ~/.aws/config;then 
+                    echo "Profile region properly configured"
+                    exit 0
+                  else
+                    echo "Profile region not properly configured"
+                    exit 1
+                  fi
+      - integration-test-install:
+          name: integration-test-configure-default-region
+          role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+          profile_name: "OIDC-User"
+          context: [CPE-OIDC]
+          configure_profile_region: false
+          region: us-west-1
+          executor: docker-base
+          post-steps:
+            - run:
+                name: Checking ~/.aws/config for default region
+                command: |
+                  if grep "\[default\]" ~/.aws/config && grep "us-west-1" ~/.aws/config;then 
+                    echo "Default region properly configured"
+                    exit 0
+                  else
+                    echo "Default region not properly configured"
+                    exit 1
+                  fi
+      # Testing OIDC
+      - integration-test-install:
+          name: integration test web identity command with white spaces
+          role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+          context: [CPE-OIDC]
+          executor: docker-base
+          post-steps:
+            - run:
+                name: Web Identity Test - Logging into ECR
+                command: aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin 122211685980.dkr.ecr.us-west-2.amazonaws.com
+      - integration-test-install:
+          name: integration-test-web-identity-parameters
+          role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+          session_duration: "${TEST_SESSION_DURATION}"
+          context: [CPE-OIDC]
+          executor: docker-base
+          role_session_name: "test-Sess!on Wi7h inv^l!d-characters that's longer than 64 chars"
+          post-steps:
+            - run:
+                name: Check Values of Expanded Variables
+                command: |
+                  if [ "${TEST_SESSION_DURATION}" -eq "900" ]; then
+                    exit 0
+                  else
+                    exit 1
+                  fi
+      - integration-test-install:
+          name: integration-test-web-identity-with-profile
+          role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+          profile_name: "OIDC-Tester"
+          context: [CPE-OIDC]
+          executor: docker-base
+          post-steps:
+            - run:
+                name: Web Identity Test - Logging into ECR
+                command: aws ecr get-login-password --region us-west-2 --profile "OIDC-Tester" | docker login --username AWS --password-stdin 122211685980.dkr.ecr.us-west-2.amazonaws.com
+      # Testing executors that do not AWS CLI pre-installed
+      - integration-test-install:
+          name: integration-test-install-<<matrix.executor>>
+          context: [CPE_ORBS_AWS]
+          matrix:
+            alias: test-install
+            parameters:
+              executor: ["docker-base", "macos", "alpine", "docker-nounset-shell", terraform ]
+          filters: *filters
+          post-steps:
+            - check_aws_version
+      # Test installing specific versions on executors without AWS pre-installed
+      - integration-test-install:
+          name: integration-test-install-version-<<matrix.executor>>
+          context: [CPE_ORBS_AWS]
+          matrix:
+            alias: test-install-version
+            parameters:
+              executor: ["docker-base", "macos", "alpine", "docker-nounset-shell" ]
+          version: "2.1.10"
+          filters: *filters
+          post-steps:
+            - check_aws_version:
+                version: "2.1.10"
+      # Test overriding existing version of AWS pre-installed
+      - integration-test-install:
+          name: integration-test-install-override-version-<<matrix.executor>>
+          context: [CPE_ORBS_AWS]
+          matrix:
+            alias: test-install-override-version
+            parameters:
+              executor: ["linuxvm", "windows", "arm"]
+          version: "2.1.10"
+          install_dir: "/usr/local/aws-cli"
+          binary_dir: ""
+          override_installed: false
+          filters: *filters
+          post-steps:
+            - check_aws_version:
+                version: "2.1.10"
       - integration-test-install:
           name: integration-test-skip-install-matched-version
           context: [CPE_ORBS_AWS]
@@ -236,51 +236,44 @@ workflows:
             alias: test-install-override-version
             parameters:
               executor: [ "arm" ]
-          version: "2.1.10"
+          version: "2.1.21"
           install_dir: "/usr/local/aws-cli"
           binary_dir: ""
-          override_installed: false
           filters: *filters
-          pre-steps:
-            - run:
-                command: |
-                  set -x
-                  aws --version
-                  set +x
           post-steps:
             - check_aws_version:
-                version: "2.1.10"
-      # - integration-test-install:
-      #     name: integration-test-install-override-version-with-latest-<<matrix.executor>>
-      #     context: [CPE_ORBS_AWS]
-      #     matrix:
-      #       alias: test-install-override-version-with-latest
-      #       parameters:
-      #         executor: ["linuxvm", "windows", "arm"]
-      #     install_dir: "/usr/local/aws-cli"
-      #     binary_dir: ""
-      #     override_installed: true
-      #     filters: *filters
-      # - integration-test-role-arn-setup:
-      #     name: integration-test-role-arn-config
-      #     source_profile: default
-      #     profile_name: CircleCI-Tester
-      #     role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
-      #     context: [CPE_ORBS_AWS]
-      #     post-steps:
-      #       - run:
-      #             name: Logging into ECR with new profile
-      #             command: aws ecr get-login-password --region us-west-2 --profile "CircleCI-Tester" | docker login --username AWS --password-stdin 122211685980.dkr.ecr.us-west-2.amazonaws.com
-      # - orb-tools/pack:
-      #     filters: *release-filters
-      # - orb-tools/publish:
-      #     orb_name: circleci/aws-cli
-      #     vcs_type: << pipeline.project.type >>
-      #     pub_type: production
-      #     enable_pr_comment: true
-      #     context: orb-publisher
-      #     requires: [orb-tools/pack, test-install, test-install-version, test-install-override-version, integration-test-web-identity-with-profile, integration test web identity command with white spaces,integration-test-role-arn-config, test-install-override-version-with-latest]
-      #     filters: *release-filters
+                version: "2.1.21"
+      - integration-test-install:
+          name: integration-test-install-override-version-with-latest-<<matrix.executor>>
+          context: [CPE_ORBS_AWS]
+          matrix:
+            alias: test-install-override-version-with-latest
+            parameters:
+              executor: ["linuxvm", "windows", "arm"]
+          install_dir: "/usr/local/aws-cli"
+          binary_dir: ""
+          override_installed: true
+          filters: *filters
+      - integration-test-role-arn-setup:
+          name: integration-test-role-arn-config
+          source_profile: default
+          profile_name: CircleCI-Tester
+          role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+          context: [CPE_ORBS_AWS]
+          post-steps:
+            - run:
+                  name: Logging into ECR with new profile
+                  command: aws ecr get-login-password --region us-west-2 --profile "CircleCI-Tester" | docker login --username AWS --password-stdin 122211685980.dkr.ecr.us-west-2.amazonaws.com
+      - orb-tools/pack:
+          filters: *release-filters
+      - orb-tools/publish:
+          orb_name: circleci/aws-cli
+          vcs_type: << pipeline.project.type >>
+          pub_type: production
+          enable_pr_comment: true
+          context: orb-publisher
+          requires: [orb-tools/pack, test-install, test-install-version, test-install-override-version, integration-test-web-identity-with-profile, integration test web identity command with white spaces,integration-test-role-arn-config, test-install-override-version-with-latest, integration-test-skip-install-matched-version]
+          filters: *release-filters
 executors:
   terraform:
     docker:

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -34,7 +34,7 @@ Toggle_Pager(){
 if ! command -v aws >/dev/null 2>&1; then
     Install_AWS_CLI "${AWS_CLI_STR_AWS_CLI_VERSION}"
     Toggle_Pager
-elif aws --version | grep "${AWS_CLI_STR_AWS_CLI_VERSION}"; then
+elif aws --version | awk '{print $2}' |grep "${AWS_CLI_STR_AWS_CLI_VERSION}"; then
     echo "AWS CLI version ${AWS_CLI_STR_AWS_CLI_VERSION} already installed. Skipping installation"
     exit 0
 elif [ "$AWS_CLI_BOOL_OVERRIDE" -eq 1 ] || [ "${AWS_CLI_STR_AWS_CLI_VERSION}" != "latest" ]; then

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -34,6 +34,9 @@ Toggle_Pager(){
 if ! command -v aws >/dev/null 2>&1; then
     Install_AWS_CLI "${AWS_CLI_STR_AWS_CLI_VERSION}"
     Toggle_Pager
+elif aws --version | grep "${AWS_CLI_STR_AWS_CLI_VERSION}"; then
+    echo "AWS CLI version ${AWS_CLI_STR_AWS_CLI_VERSION} already installed. Skipping installation"
+    exit 0
 elif [ "$AWS_CLI_BOOL_OVERRIDE" -eq 1 ] || [ "${AWS_CLI_STR_AWS_CLI_VERSION}" != "latest" ]; then
     Uninstall_AWS_CLI
     Install_AWS_CLI "${AWS_CLI_STR_AWS_CLI_VERSION}"


### PR DESCRIPTION
If a user specifies a version of the `aws cli` to install, the orb always uninstalls the any pre-installed version before installing the specified one. It does not check to see if the user's specified version is already installed. 

This `PR` checks to see if the the user's version matches the pre-installed version of the `aws-cli`. If it does, it skips the installation process.
