### PR TITLE
feat: set_aws_env_vars

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -56,7 +56,10 @@ jobs:
       region:
         type: string
         default: ${AWS_DEFAULT_REGION}
-    executor: <<parameters.executor>>
+      set_aws_env_vars:
+        type: boolean
+        default: true
+        executor: <<parameters.executor>>
     steps:
       - aws-cli/setup:
           version: <<parameters.version>>
@@ -70,6 +73,7 @@ jobs:
           configure_default_region: <<parameters.configure_default_region>>
           configure_profile_region: <<parameters.configure_profile_region>>
           region: <<parameters.region>>
+          set_aws_env_vars: <<parameter.set_aws_env_vars>>
       - run:
           name: Test that paging is disabled
           command: |-
@@ -173,7 +177,7 @@ workflows:
           set_aws_env_vars: false
           post-steps:
             - run:
-                name: Check Values of Expanded Variables
+                name: Check for temporary file containing keys
                 command: |
                   if [  -f "/tmp/default.keys" ]; then
                     exit 0
@@ -181,7 +185,7 @@ workflows:
                     exit 1
                   fi
             - run:
-                name: Check for temporary file containing keys
+                name: Check Values of Expanded Variables
                 command: |
                   if [ "${TEST_SESSION_DURATION}" -eq "900" ]; then
                     exit 0

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -170,9 +170,18 @@ workflows:
           context: [CPE-OIDC]
           executor: docker-base
           role_session_name: "test-Sess!on Wi7h inv^l!d-characters that's longer than 64 chars"
+          set_aws_env_vars: false
           post-steps:
             - run:
                 name: Check Values of Expanded Variables
+                command: |
+                  if [  -f "/tmp/default.keys" ]; then
+                    exit 0
+                  else
+                    exit 1
+                  fi
+            - run:
+                name: Check for temporary file containing keys
                 command: |
                   if [ "${TEST_SESSION_DURATION}" -eq "900" ]; then
                     exit 0

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -77,7 +77,6 @@ jobs:
       - run:
           name: Test that paging is disabled
           command: |-
-            set -x
             # Test with aws command that would require paging if a pager is enabled
             touch "${BASH_ENV}"
             . "${BASH_ENV}"
@@ -85,7 +84,6 @@ jobs:
             aws ec2 describe-images --profile << parameters.profile_name >> \
               --owners amazon \
               --filters "Name=platform,Values=windows" "Name=root-device-type,Values=ebs" 
-            set +x
   integration-test-role-arn-setup:
     executor: docker-base
     parameters:
@@ -181,9 +179,7 @@ workflows:
             - run:
                 name: Check for temporary file containing keys
                 command: |
-                  if [  -f "/tmp/default.keys" ]; then
-                    exit 0
-                  else
+                  if [ ! -f "/tmp/default.keys" ]; then
                     exit 1
                   fi
             - run:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -59,7 +59,7 @@ jobs:
       set_aws_env_vars:
         type: boolean
         default: true
-        executor: <<parameters.executor>>
+    executor: <<parameters.executor>>
     steps:
       - aws-cli/setup:
           version: <<parameters.version>>
@@ -73,10 +73,11 @@ jobs:
           configure_default_region: <<parameters.configure_default_region>>
           configure_profile_region: <<parameters.configure_profile_region>>
           region: <<parameters.region>>
-          set_aws_env_vars: <<parameter.set_aws_env_vars>>
+          set_aws_env_vars: <<parameters.set_aws_env_vars>>
       - run:
           name: Test that paging is disabled
           command: |-
+            set -x
             # Test with aws command that would require paging if a pager is enabled
             touch "${BASH_ENV}"
             . "${BASH_ENV}"
@@ -84,6 +85,7 @@ jobs:
             aws ec2 describe-images --profile << parameters.profile_name >> \
               --owners amazon \
               --filters "Name=platform,Values=windows" "Name=root-device-type,Values=ebs" 
+            set +x
   integration-test-role-arn-setup:
     executor: docker-base
     parameters:

--- a/src/commands/assume_role_with_web_identity.yml
+++ b/src/commands/assume_role_with_web_identity.yml
@@ -33,13 +33,21 @@ parameters:
     type: string
     default: ${AWS_DEFAULT_REGION}
 
+  set_aws_env_vars:
+    description: |
+      Set this to false to write keys generated from OIDC to a temporary file.
+      By default, the keys are written to $BASH_ENV.
+    type: boolean
+    default: true
+
 steps:
   - run:
-      name: Generate shortlived AWS Keys using CircleCI OIDC token.
+      name: Generate short lived AWS Keys using CircleCI OIDC token.
       environment:
         AWS_CLI_STR_ROLE_ARN: <<parameters.role_arn>>
         AWS_CLI_STR_ROLE_SESSION_NAME: <<parameters.role_session_name>>
         AWS_CLI_INT_SESSION_DURATION: <<parameters.session_duration>>
         AWS_CLI_STR_PROFILE_NAME: <<parameters.profile_name>>
         AWS_CLI_STR_REGION: <<parameters.region>>
+        AWS_CLI_BOOL_SET_AWS_ENV_VARS: <<parameters.set_aws_env_vars>>
       command: <<include(scripts/assume_role_with_web_identity.sh)>>

--- a/src/commands/assume_role_with_web_identity.yml
+++ b/src/commands/assume_role_with_web_identity.yml
@@ -35,7 +35,8 @@ parameters:
 
   set_aws_env_vars:
     description: |
-      Set this to false to write keys generated from OIDC to a temporary file.
+      Write AWS keys generated from OIDC to a temporary file.
+      Set to false if generating keys for multiple profiles.
       By default, the keys are written to $BASH_ENV.
     type: boolean
     default: true

--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -94,7 +94,8 @@ parameters:
 
   set_aws_env_vars:
     description: |
-      Set this to false to write keys generated from OIDC to a temporary file.
+      Write AWS keys generated from OIDC to a temporary file.
+      Set to false if generating keys for multiple profiles.
       By default, the keys are written to $BASH_ENV.
     type: boolean
     default: true

--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -118,7 +118,7 @@ steps:
             session_duration: <<parameters.session_duration>>
             profile_name: <<parameters.profile_name>>
             region: <<parameters.region>>
-            set_aws_env_vars: <<parameter.set_aws_env_vars>>
+            set_aws_env_vars: <<parameters.set_aws_env_vars>>
   - run:
       name: Configure AWS Access Key ID
       environment:
@@ -128,4 +128,5 @@ steps:
         AWS_CLI_BOOL_CONFIG_DEFAULT_REGION: <<parameters.configure_default_region>>
         AWS_CLI_BOOL_CONFIG_PROFILE_REGION: <<parameters.configure_profile_region>>
         AWS_CLI_STR_REGION: <<parameters.region>>
+        AWS_CLI_BOOL_SET_AWS_ENV_VARS: <<parameters.set_aws_env_vars>>
       command: <<include(scripts/configure.sh)>>

--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -92,6 +92,13 @@ parameters:
     type: string
     default: "3600"
 
+  set_aws_env_vars:
+    description: |
+      Set this to false to write keys generated from OIDC to a temporary file.
+      By default, the keys are written to $BASH_ENV.
+    type: boolean
+    default: true
+
 steps:
   - install:
       version: <<parameters.version>>
@@ -111,6 +118,7 @@ steps:
             session_duration: <<parameters.session_duration>>
             profile_name: <<parameters.profile_name>>
             region: <<parameters.region>>
+            set_aws_env_vars: <<parameter.set_aws_env_vars>>
   - run:
       name: Configure AWS Access Key ID
       environment:

--- a/src/scripts/assume_role_with_web_identity.sh
+++ b/src/scripts/assume_role_with_web_identity.sh
@@ -4,6 +4,7 @@ AWS_CLI_STR_ROLE_ARN="$(echo "${AWS_CLI_STR_ROLE_ARN}" | circleci env subst)"
 AWS_CLI_STR_PROFILE_NAME="$(echo "${AWS_CLI_STR_PROFILE_NAME}" | circleci env subst)"
 AWS_CLI_STR_REGION="$(echo "${AWS_CLI_STR_REGION}" | circleci env subst)"
 AWS_CLI_INT_SESSION_DURATION="$(echo "${AWS_CLI_INT_SESSION_DURATION}" | circleci env subst)"
+AWS_CLI_BOOL_SET_AWS_ENV_VARS="$(echo "${AWS_CLI_BOOL_SET_AWS_ENV_VARS}" | circleci env subst)"
 
 # Sanitise role session name
 # Remove invalid characters
@@ -40,17 +41,25 @@ $(aws sts assume-role-with-web-identity \
 --output text)
 EOF
 
-temp_file="/tmp/${AWS_CLI_STR_PROFILE_NAME}.keys"
-touch "$temp_file"
-
 if [ -z "${AWS_ACCESS_KEY_ID}" ] || [ -z "${AWS_SECRET_ACCESS_KEY}" ] || [ -z "${AWS_SESSION_TOKEN}" ]; then
     echo "Failed to assume role";
     exit 1
+elif [ "${AWS_CLI_BOOL_SET_AWS_ENV_VARS}" = 1 ]; then
+    {
+        echo "export AWS_CLI_STR_ACCESS_KEY_ID=\"${AWS_ACCESS_KEY_ID}\""
+        echo "export AWS_CLI_STR_SECRET_ACCESS_KEY=\"${AWS_SECRET_ACCESS_KEY}\""
+        echo "export AWS_CLI_STR_SESSION_TOKEN=\"${AWS_SESSION_TOKEN}\""
+    }  >> "$BASH_ENV"
+
+    echo "AWS keys successfully written to BASH_ENV"
 else
+    temp_file="/tmp/${AWS_CLI_STR_PROFILE_NAME}.keys"
+    touch "$temp_file"
     {
         echo "export AWS_CLI_STR_ACCESS_KEY_ID=\"${AWS_ACCESS_KEY_ID}\""
         echo "export AWS_CLI_STR_SECRET_ACCESS_KEY=\"${AWS_SECRET_ACCESS_KEY}\""
         echo "export AWS_CLI_STR_SESSION_TOKEN=\"${AWS_SESSION_TOKEN}\""
     }  >> "$temp_file"
-    echo "Assume role with web identity succeeded"
+    
+    echo "AWS keys successfully written to ${AWS_CLI_STR_PROFILE_NAME}.keys"
 fi

--- a/src/scripts/assume_role_with_web_identity.sh
+++ b/src/scripts/assume_role_with_web_identity.sh
@@ -6,11 +6,9 @@ AWS_CLI_STR_REGION="$(echo "${AWS_CLI_STR_REGION}" | circleci env subst)"
 AWS_CLI_INT_SESSION_DURATION="$(echo "${AWS_CLI_INT_SESSION_DURATION}" | circleci env subst)"
 AWS_CLI_BOOL_SET_AWS_ENV_VARS="$(echo "${AWS_CLI_BOOL_SET_AWS_ENV_VARS}" | circleci env subst)"
 
-# Sanitise role session name
-# Remove invalid characters
 AWS_CLI_STR_ROLE_SESSION_NAME=$(echo "${AWS_CLI_STR_ROLE_SESSION_NAME}" | tr -sC 'A-Za-z0-9=,.@_\-' '-')
-# Trim to 64 characters
 AWS_CLI_STR_ROLE_SESSION_NAME=$(echo "${AWS_CLI_STR_ROLE_SESSION_NAME}" | cut -c -64)
+
 if [ -z "${AWS_CLI_STR_ROLE_SESSION_NAME}" ]; then
     echo "Role session name is required"
     exit 1

--- a/src/scripts/configure.sh
+++ b/src/scripts/configure.sh
@@ -5,10 +5,14 @@ AWS_CLI_STR_SECRET_ACCESS_KEY="$(echo "\$$AWS_CLI_STR_SECRET_ACCESS_KEY" | circl
 AWS_CLI_STR_SESSION_TOKEN="$(echo "$AWS_CLI_STR_SESSION_TOKEN" | circleci env subst)"
 AWS_CLI_STR_REGION="$(echo "$AWS_CLI_STR_REGION" | circleci env subst)"
 AWS_CLI_STR_PROFILE_NAME="$(echo "$AWS_CLI_STR_PROFILE_NAME" | circleci env subst)"
+AWS_CLI_BOOL_SET_AWS_ENV_VARS="$(echo "$AWS_CLI_BOOL_SET_AWS_ENV_VARS" | circleci env subst)"
 
-if [ -z "$AWS_CLI_STR_ACCESS_KEY_ID" ] && [ -z "${AWS_CLI_STR_SECRET_ACCESS_KEY}" ]; then 
+if [ -z "$AWS_CLI_STR_ACCESS_KEY_ID" ] && [ -z "${AWS_CLI_STR_SECRET_ACCESS_KEY}" ] && [ "$AWS_CLI_BOOL_SET_AWS_ENV_VARS" = 0 ]; then 
     temp_file="/tmp/${AWS_CLI_STR_PROFILE_NAME}.keys"
     . "$temp_file"
+else 
+    touch "${BASH_ENV}"
+    . "${BASH_ENV}"
 fi
 
 aws configure set aws_access_key_id \
@@ -33,4 +37,3 @@ if [ "$AWS_CLI_BOOL_CONFIG_PROFILE_REGION" -eq "1" ]; then
     aws configure set region "$AWS_CLI_STR_REGION" \
         --profile "$AWS_CLI_STR_PROFILE_NAME"
 fi
-


### PR DESCRIPTION
Currently, the `assume_role_with_web_identity` command generates temporary AWS keys that gets written to a temporary file, enabling users to create multiple profiles without having to alter `BASH_ENV`. This was helpful for users who ran workflows requiring multiple profiles to run their `aws` commands. 

However, this change broke for many users (see #179) who were relying on the AWS key being written to `BASH_ENV`. 

This pull request adds ads the `set_aws_env_vars` parameter to the `assume_role_with_web_identity` command that enables to write the keys to a temporary file when set to `false`. Otherwise, it automatically writes to `BASH_ENV` by default. 