### PR TITLE
chore: setup automatically on assume role with web identity command

### DIFF
--- a/src/commands/assume_role_with_web_identity.yml
+++ b/src/commands/assume_role_with_web_identity.yml
@@ -42,6 +42,13 @@ parameters:
     default: true
 
 steps:
+  - setup:
+      role_arn: <<parameters.role_arn>>
+      role_session_name: <<parameters.role_session_name>>
+      session_duration: <<parameters.session_duration>>
+      profile_name: <<parameters.profile_name>>
+      region: <<parameters.region>>
+      set_aws_env_vars: <<parameters.set_aws_env_vars>>
   - run:
       name: Generate short lived AWS Keys using CircleCI OIDC token.
       environment:

--- a/src/examples/configure_role_arn.yml
+++ b/src/examples/configure_role_arn.yml
@@ -5,7 +5,7 @@ usage:
   version: 2.1
 
   orbs:
-    aws-cli: circleci/aws-cli@4.0
+    aws-cli: circleci/aws-cli@4.1
 
   jobs:
     configure_role_arn:

--- a/src/examples/install_aws_cli.yml
+++ b/src/examples/install_aws_cli.yml
@@ -3,7 +3,7 @@ usage:
   version: 2.1
 
   orbs:
-    aws-cli: circleci/aws-cli@4.0
+    aws-cli: circleci/aws-cli@4.1
 
   jobs:
     aws-cli-example:

--- a/src/examples/install_aws_cli_with_web_identity.yml
+++ b/src/examples/install_aws_cli_with_web_identity.yml
@@ -6,14 +6,14 @@ usage:
   version: 2.1
 
   orbs:
-    aws-cli: circleci/aws-cli@4.0
+    aws-cli: circleci/aws-cli@4.1
 
   jobs:
     aws-cli-example:
       executor: aws-cli/default
       steps:
         - checkout
-        - aws-cli/setup:
+        - aws-cli/assume_role_with_identity:
             profile_name: WEB IDENTITY PROFILE
             role_arn: arn:aws:iam::123456789012:role/WEB-IDENTITY-ROLE
             role_session_name: example-session


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

this helps users to call `assume_role_with_web_identity` command without calling `setup` command.

eg:
```
jobs:
  aiaws-bedrock:
    executor: python
    environment:
      AWS_REGION: us-east-1
    steps:
      - checkout
      - aws-cli/assume_role_with_web_identity:
          role_arn: $CIRCLE_AWS_ROLE_ARN
          role_session_name: "cci-oidc-session"
```

instead of 

```
jobs:
  aiaws-bedrock:
    executor: python
    environment:
      AWS_REGION: us-east-1
    steps:
      - checkout
      - aws-cli/setup:
          role_arn: $CIRCLE_AWS_ROLE_ARN
          role_session_name: "cci-oidc-session"
      - aws-cli/assume_role_with_web_identity:
          role_arn: $CIRCLE_AWS_ROLE_ARN
          role_session_name: "cci-oidc-session"
```