### PR TITLE
Fix Setup with OIDC role failing when access key env are set

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -348,7 +348,7 @@ executors:
       - image: cimg/base:stable
   docker-base-withenv:
     docker:
-      - image: 
+      - image: cimg/base:stable
         environment:
           AWS_ACCESS_KEY_ID: "key"
           AWS_SECRET_ACCESS_KEY: "secret"      

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -115,9 +115,63 @@ jobs:
               echo Wrong configuration set.
               exit 1
             fi
+  integration-test-oidc-setup:
+    parameters:
+      executor:
+        type: executor
+      role_arn:
+        type: string
+        default: ""
+      role_session_name:
+        description: An identifier for the assumed role session
+        type: string
+        default: ${CIRCLE_JOB}
+      profile_name:
+        description: Profile name to be configured.
+        type: string
+        default: "default"
+      access_key_id:
+        description: Access key to login.
+        type: string
+        default: ""
+      secret_access_key:
+        description: Secret to login.
+        type: string
+        default: ""
+      region:
+        type: string
+        default: ${AWS_DEFAULT_REGION}
+    executor: <<parameters.executor>>
+    steps:
+      - aws-cli/setup:
+          role_arn: <<parameters.role_arn>>
+          profile_name: <<parameters.profile_name>>
+          role_session_name: <<parameters.role_session_name>>
+          region: <<parameters.region>>
 workflows:
   test-deploy:
     jobs:
+      # Testing auth uses oidc whe specified together with env variables
+      - integration-test-oidc-setup:
+          name: integration-test-oidc-withenv
+          role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+          profile_name: integration-test
+          region: us-west-2
+          executor: docker-base-withenv
+          post-steps:
+            - run:
+                name: Validating auth
+                command: aws sts get-caller-identity --profile integration-test
+      - integration-test-oidc-setup:
+          name: integration-test-oidc-with-noenv
+          role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+          profile_name: integration-test
+          region: us-west-2
+          executor: docker-base
+          post-steps:
+            - run:
+                name: Validating auth
+                command: aws sts get-caller-identity --profile integration-test                
       # Testing region configuration
       - integration-test-install:
           name: integration-test-configure-profile-region
@@ -292,6 +346,12 @@ executors:
   docker-base:
     docker:
       - image: cimg/base:stable
+  docker-base-withenv:
+    docker:
+    - image: 
+      environment:
+        AWS_ACCESS_KEY_ID: "key"
+        AWS_SECRET_ACCESS_KEY: "secret"      
   docker-nounset-shell:
     shell: /bin/bash -o nounset
     docker:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -156,6 +156,7 @@ workflows:
       - integration-test-oidc-setup:
           name: integration-test-oidc-withenv
           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+          context: [CPE_ORBS_AWS]
           profile_name: integration-test
           region: us-west-2
           executor: docker-base-withenv
@@ -166,6 +167,7 @@ workflows:
       - integration-test-oidc-setup:
           name: integration-test-oidc-with-noenv
           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+          context: [CPE_ORBS_AWS]
           profile_name: integration-test
           region: us-west-2
           executor: docker-base

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -348,10 +348,10 @@ executors:
       - image: cimg/base:stable
   docker-base-withenv:
     docker:
-    - image: 
-      environment:
-        AWS_ACCESS_KEY_ID: "key"
-        AWS_SECRET_ACCESS_KEY: "secret"      
+      - image: 
+        environment:
+          AWS_ACCESS_KEY_ID: "key"
+          AWS_SECRET_ACCESS_KEY: "secret"      
   docker-nounset-shell:
     shell: /bin/bash -o nounset
     docker:

--- a/src/scripts/configure.sh
+++ b/src/scripts/configure.sh
@@ -7,7 +7,7 @@ AWS_CLI_STR_REGION="$(echo "$AWS_CLI_STR_REGION" | circleci env subst)"
 AWS_CLI_STR_PROFILE_NAME="$(echo "$AWS_CLI_STR_PROFILE_NAME" | circleci env subst)"
 AWS_CLI_BOOL_SET_AWS_ENV_VARS="$(echo "$AWS_CLI_BOOL_SET_AWS_ENV_VARS" | circleci env subst)"
 
-if [ "$AWS_CLI_BOOL_SET_AWS_ENV_VARS" = 0 ]; then 
+if [ -z "$AWS_CLI_STR_ACCESS_KEY_ID" ] && [ -z "${AWS_CLI_STR_SECRET_ACCESS_KEY}" ] && [ "$AWS_CLI_BOOL_SET_AWS_ENV_VARS" = 0 ]; then 
     temp_file="/tmp/${AWS_CLI_STR_PROFILE_NAME}.keys"
     . "$temp_file"
 else 

--- a/src/scripts/configure.sh
+++ b/src/scripts/configure.sh
@@ -7,7 +7,7 @@ AWS_CLI_STR_REGION="$(echo "$AWS_CLI_STR_REGION" | circleci env subst)"
 AWS_CLI_STR_PROFILE_NAME="$(echo "$AWS_CLI_STR_PROFILE_NAME" | circleci env subst)"
 AWS_CLI_BOOL_SET_AWS_ENV_VARS="$(echo "$AWS_CLI_BOOL_SET_AWS_ENV_VARS" | circleci env subst)"
 
-if [ -z "$AWS_CLI_STR_ACCESS_KEY_ID" ] && [ -z "${AWS_CLI_STR_SECRET_ACCESS_KEY}" ] && [ "$AWS_CLI_BOOL_SET_AWS_ENV_VARS" = 0 ]; then 
+if [ "$AWS_CLI_BOOL_SET_AWS_ENV_VARS" = 0 ]; then 
     temp_file="/tmp/${AWS_CLI_STR_PROFILE_NAME}.keys"
     . "$temp_file"
 else 


### PR DESCRIPTION
### Motivation, issues

As detailed in the  #193  OIDC is not working when the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are setup as environment variables in the job. This is happening because there's a condition checking for OIDC to be set and the two variables not to be. I'm updating the condition to only check for OIDC and ignore the variables.
I'm also adding two new tests to validate this behavior