### PR TITLE
Feat/add brew install option

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -154,30 +154,9 @@ jobs:
     steps:
       - aws-cli/install:
           use_brew: true
-  integration-test-brew-install-python-new:
-    executor: macos
-    steps:
-      - run:
-          name: Install python 3.12
-          command: |-
-            which pyenv
-            brew upgrade pyenv
-            pyenv install 3.12
-            pyenv global 3.12
-            pyenv uninstall 3.11
-      - run:
-          name: Verify python version
-          command: |-
-            which python
-            python --version
-      - aws-cli/install:
-          use_brew: true
 workflows:
   test-deploy:
     jobs:
-      - integration-test-brew-install-python-new:
-          post-steps:
-            - check_aws_version
       - integration-test-brew-install:
           post-steps:
             - check_aws_version

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -154,7 +154,7 @@ jobs:
     steps:
       - aws-cli/install:
           use_brew: true
-  integration-test-brew-install-python3.12:
+  integration-test-brew-install-python-new:
     executor: macos
     steps:
       - run:
@@ -167,7 +167,7 @@ jobs:
 workflows:
   test-deploy:
     jobs:
-      - integration-test-brew-install-python3.12:
+      - integration-test-brew-install-python-new:
           post-steps:
             - check_aws_version
       - integration-test-brew-install:
@@ -359,7 +359,7 @@ workflows:
           pub_type: production
           enable_pr_comment: true
           context: orb-publisher
-          requires: [orb-tools/pack, test-install, test-install-version, test-install-override-version, integration-test-web-identity-with-profile, integration test web identity command with white spaces,integration-test-role-arn-config, test-install-override-version-with-latest, integration-test-skip-install-matched-version, integration-test-brew-install]
+          requires: [orb-tools/pack, test-install, test-install-version, test-install-override-version, integration-test-web-identity-with-profile, integration test web identity command with white spaces,integration-test-role-arn-config, test-install-override-version-with-latest, integration-test-skip-install-matched-version, integration-test-brew-install, integration-test-brew-install-python-new]
           filters: *release-filters
 executors:
   terraform:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -160,8 +160,8 @@ jobs:
       - run:
           name: Install python 3.12
           command: |-
-            brew install python@3.12
-            ln -s -f /opt/homebrew/bin/python3 /usr/local/bin/python
+            pyenv install 3.12
+            pyenv global 3.12
       - run:
           name: Verify python version
           command: |-

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -160,6 +160,7 @@ jobs:
       - run:
           name: Install python 3.12
           command: |-
+            brew uninstall python@3.11
             brew install python@3.12
             python --version
       - aws-cli/install:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -160,7 +160,6 @@ jobs:
       - run:
           name: Install python 3.12
           command: |-
-            rm /usr/local/bin/python
             brew install python@3.12
             ln -s -f /opt/homebrew/bin/python3 /usr/local/bin/python
       - run:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -160,8 +160,8 @@ jobs:
       - run:
           name: Install python 3.12
           command: |-
-            brew install python@3.12
             rm /usr/local/bin/python
+            brew install python@3.12
             ln -s -f /opt/homebrew/bin/python3 /usr/local/bin/python
       - run:
           name: Verify python version

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -154,22 +154,12 @@ jobs:
     steps:
       - aws-cli/install:
           use_brew: true
-  integration-test-brew-install-version:
-    executor: macos
-    steps:
-      - aws-cli/install:
-          use_brew: true
-          version: "2.15.57"
 workflows:
   test-deploy:
     jobs:
       - integration-test-brew-install:
           post-steps:
-            - check_aws_version      
-      - integration-test-brew-install-version:
-          post-steps:
-            - check_aws_version:
-                version: "2.15.57"
+            - check_aws_version
       # Testing auth uses oidc whe specified together with env variables
       - integration-test-oidc-setup:
           name: integration-test-oidc-withenv
@@ -356,7 +346,7 @@ workflows:
           pub_type: production
           enable_pr_comment: true
           context: orb-publisher
-          requires: [orb-tools/pack, test-install, test-install-version, test-install-override-version, integration-test-web-identity-with-profile, integration test web identity command with white spaces,integration-test-role-arn-config, test-install-override-version-with-latest, integration-test-skip-install-matched-version, integration-test-brew-install-version, integration-test-brew-install]
+          requires: [orb-tools/pack, test-install, test-install-version, test-install-override-version, integration-test-web-identity-with-profile, integration test web identity command with white spaces,integration-test-role-arn-config, test-install-override-version-with-latest, integration-test-skip-install-matched-version, integration-test-brew-install]
           filters: *release-filters
 executors:
   terraform:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -149,9 +149,27 @@ jobs:
           profile_name: <<parameters.profile_name>>
           role_session_name: <<parameters.role_session_name>>
           region: <<parameters.region>>
+  integration-test-brew-install:
+    executor: macos
+    steps:
+      - aws-cli/install:
+          use_brew: true
+  integration-test-brew-install-version:
+    executor: macos
+    steps:
+      - aws-cli/install:
+          use_brew: true
+          version: "2.15.57"
 workflows:
   test-deploy:
     jobs:
+      - integration-test-brew-install:
+          post-steps:
+            - check_aws_version      
+      - integration-test-brew-install-version:
+          post-steps:
+            - check_aws_version:
+                version: "2.15.57"
       # Testing auth uses oidc whe specified together with env variables
       - integration-test-oidc-setup:
           name: integration-test-oidc-withenv
@@ -338,7 +356,7 @@ workflows:
           pub_type: production
           enable_pr_comment: true
           context: orb-publisher
-          requires: [orb-tools/pack, test-install, test-install-version, test-install-override-version, integration-test-web-identity-with-profile, integration test web identity command with white spaces,integration-test-role-arn-config, test-install-override-version-with-latest, integration-test-skip-install-matched-version]
+          requires: [orb-tools/pack, test-install, test-install-version, test-install-override-version, integration-test-web-identity-with-profile, integration test web identity command with white spaces,integration-test-role-arn-config, test-install-override-version-with-latest, integration-test-skip-install-matched-version, integration-test-brew-install-version, integration-test-brew-install]
           filters: *release-filters
 executors:
   terraform:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -346,7 +346,7 @@ workflows:
           pub_type: production
           enable_pr_comment: true
           context: orb-publisher
-          requires: [orb-tools/pack, test-install, test-install-version, test-install-override-version, integration-test-web-identity-with-profile, integration test web identity command with white spaces,integration-test-role-arn-config, test-install-override-version-with-latest, integration-test-skip-install-matched-version, integration-test-brew-install, integration-test-brew-install-python-new]
+          requires: [orb-tools/pack, test-install, test-install-version, test-install-override-version, integration-test-web-identity-with-profile, integration test web identity command with white spaces,integration-test-role-arn-config, test-install-override-version-with-latest, integration-test-skip-install-matched-version, integration-test-brew-install]
           filters: *release-filters
 executors:
   terraform:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -160,8 +160,11 @@ jobs:
       - run:
           name: Install python 3.12
           command: |-
-            brew uninstall python@3.11
             brew install python@3.12
+            ln -s -f /usr/local/bin/python3.12 /usr/local/bin/python
+      - run:
+          name: Install python 3.12
+          command: |-
             python --version
       - aws-cli/install:
           use_brew: true

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -161,9 +161,9 @@ jobs:
           name: Install python 3.12
           command: |-
             brew install python@3.12
-            ln -s -f /usr/local/bin/python3.12 /usr/local/bin/python
+            ln -s -f /opt/homebrew/bin/python3 /usr/local/bin/python
       - run:
-          name: Install python 3.12
+          name: Verify python version
           command: |-
             python --version
       - aws-cli/install:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -158,12 +158,12 @@ jobs:
     executor: macos
     steps:
       - run:
-        name: Install python 3.12
-        command: |-
-          brew install python@3.12
-          python --version
-      - aws-cli-install:
-        use_brew: true
+          name: Install python 3.12
+          command: |-
+            brew install python@3.12
+            python --version
+      - aws-cli/install:
+          use_brew: true
 workflows:
   test-deploy:
     jobs:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -164,6 +164,7 @@ jobs:
             brew upgrade pyenv
             pyenv install 3.12
             pyenv global 3.12
+            pyenv uninstall 3.11
       - run:
           name: Verify python version
           command: |-

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -160,6 +160,8 @@ jobs:
       - run:
           name: Install python 3.12
           command: |-
+            which pyenv
+            brew upgrade pyenv
             pyenv install 3.12
             pyenv global 3.12
       - run:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -154,9 +154,22 @@ jobs:
     steps:
       - aws-cli/install:
           use_brew: true
+  integration-test-brew-install-python3.12:
+    executor: macos
+    steps:
+      - run:
+        name: Install python 3.12
+        command: |-
+          brew install python@3.12
+          python --version
+      - aws-cli-install:
+        use_brew: true
 workflows:
   test-deploy:
     jobs:
+      - integration-test-brew-install-python3.12:
+          post-steps:
+            - check_aws_version
       - integration-test-brew-install:
           post-steps:
             - check_aws_version

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -161,10 +161,12 @@ jobs:
           name: Install python 3.12
           command: |-
             brew install python@3.12
+            rm /usr/local/bin/python
             ln -s -f /opt/homebrew/bin/python3 /usr/local/bin/python
       - run:
           name: Verify python version
           command: |-
+            which python
             python --version
       - aws-cli/install:
           use_brew: true

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ CircleCI orb for installing and configuring the AWS CLI in your CircleCI jobs.
 Please visit the the Orb Registry's [usage examples](https://circleci.com/developer/orbs/orb/circleci/aws-cli#usage-install-aws-cli) for the `install-aws-cli` example.
 
 ### How to Contribute
-We welcome [issues](https://github.com/CircleCI-Public/aws-ecr-orb/issues) to and [pull requests](https://github.com/CircleCI-Public/aws-ecr-orb/pulls) against this repository! 
+We welcome [issues](https://github.com/CircleCI-Public/aws-cli-orb/issues) to and [pull requests](https://github.com/CircleCI-Public/aws-cli-orb/pulls) against this repository! 
 
 
 For further questions/comments about this or other orbs, visit [CircleCI's Orbs discussion forum](https://discuss.circleci.com/c/orbs).

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -30,7 +30,7 @@ parameters:
     type: boolean
     default: false
     description: |
-      Set to true if you want to use brew to install the awscli. Only compatible with MacOs executor. Default to false.
+      Set to true if you want to use the Homebrew CLI to install the awscli. Only compatible with the macOS executor. Defaults to false.
       When using brew, only the brew version is available.
 steps:
   - run:

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -26,6 +26,11 @@ parameters:
     default: /usr/local/bin
     description: |
       The main aws program in the install directory is symbolically linked to the file aws in the specified path. Defaults to /usr/local/bin
+  use_brew:
+    type: boolean
+    default: false
+    description: |
+      Set to true if you want to use brew to install the awscli. Only compatible with MacOs executor. Default to false.
 steps:
   - run:
       name: Install AWS CLI - <<parameters.version>>
@@ -38,5 +43,6 @@ steps:
         SCRIPT_INSTALL_WINDOWS: << include(scripts/windows/install.sh) >>
         SCRIPT_INSTALL_LINUX: << include(scripts/linux/install.sh) >>
         SCRIPT_INSTALL_MACOS: << include(scripts/macos/install.sh) >>
+        USE_BREW: <<parameters.use_brew>>
         SCRIPT_UTILS: << include(scripts/utils.sh) >>
       command: <<include(scripts/install.sh)>>

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -31,6 +31,7 @@ parameters:
     default: false
     description: |
       Set to true if you want to use brew to install the awscli. Only compatible with MacOs executor. Default to false.
+      When using brew, only the brew version is available.
 steps:
   - run:
       name: Install AWS CLI - <<parameters.version>>

--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -106,6 +106,7 @@ parameters:
     default: false
     description: |
       Set to true if you want to use brew to install the awscli. Only compatible with MacOs executor. Default to false.
+      When using brew, only the brew version is available.
 
 steps:
   - install:

--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -101,6 +101,12 @@ parameters:
     type: boolean
     default: true
 
+  use_brew:
+    type: boolean
+    default: false
+    description: |
+      Set to true if you want to use brew to install the awscli. Only compatible with MacOs executor. Default to false.    
+
 steps:
   - install:
       version: <<parameters.version>>
@@ -108,6 +114,7 @@ steps:
       override_installed: <<parameters.override_installed>>
       install_dir: <<parameters.install_dir>>
       binary_dir: <<parameters.binary_dir>>
+      use_brew: <<parameters.use_brew>>
   - when:
       condition:
         and:

--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -105,7 +105,7 @@ parameters:
     type: boolean
     default: false
     description: |
-      Set to true if you want to use brew to install the awscli. Only compatible with MacOs executor. Default to false.    
+      Set to true if you want to use brew to install the awscli. Only compatible with MacOs executor. Default to false.
 
 steps:
   - install:

--- a/src/examples/configure_role_arn.yml
+++ b/src/examples/configure_role_arn.yml
@@ -5,7 +5,7 @@ usage:
   version: 2.1
 
   orbs:
-    aws-cli: circleci/aws-cli@4.0
+    aws-cli: circleci/aws-cli@5.1
 
   jobs:
     configure_role_arn:

--- a/src/examples/install_aws_cli.yml
+++ b/src/examples/install_aws_cli.yml
@@ -3,7 +3,7 @@ usage:
   version: 2.1
 
   orbs:
-    aws-cli: circleci/aws-cli@4.0
+    aws-cli: circleci/aws-cli@5.1
 
   jobs:
     aws-cli-example:

--- a/src/examples/install_aws_cli_with_web_identity.yml
+++ b/src/examples/install_aws_cli_with_web_identity.yml
@@ -6,7 +6,7 @@ usage:
   version: 2.1
 
   orbs:
-    aws-cli: circleci/aws-cli@4.0
+    aws-cli: circleci/aws-cli@5.1
 
   jobs:
     aws-cli-example:

--- a/src/scripts/macos/install.sh
+++ b/src/scripts/macos/install.sh
@@ -1,20 +1,29 @@
 #!/bin/sh
 Install_AWS_CLI() {
-    if [ "$1" = "latest" ]; then
-        version=""
-    else
-        version="-$1"
-    fi
     echo "Installing AWS CLI v$version"
-    cd /tmp || exit
-    curl -o awscli.tar.gz "https://awscli.amazonaws.com/awscli$version.tar.gz"
-    mkdir awscli
-    tar -xzf awscli.tar.gz -C awscli --strip-components=1
-    rm awscli.tar.gz
-    cd awscli || exit
-    ./configure --with-download-deps
-    make
-    $SUDO make install
+    if [ "$USE_BREW" -eq 1 ]; then
+        if [ "$1" = "latest" ]; then
+            version=""
+        else
+            version="@$1"
+        fi
+        brew install awscli$version
+    else
+        if [ "$1" = "latest" ]; then
+            version=""
+        else
+            version="-$1"
+        fi
+        cd /tmp || exit
+        curl -o awscli.tar.gz "https://awscli.amazonaws.com/awscli$version.tar.gz"
+        mkdir awscli
+        tar -xzf awscli.tar.gz -C awscli --strip-components=1
+        rm awscli.tar.gz
+        cd awscli || exit
+        ./configure --with-download-deps
+        make
+        $SUDO make install
+    fi
 }
 
 Uninstall_AWS_CLI() {

--- a/src/scripts/macos/install.sh
+++ b/src/scripts/macos/install.sh
@@ -7,7 +7,7 @@ Install_AWS_CLI() {
         else
             version="@$1"
         fi
-        brew install awscli$version
+        brew install "awscli$version"
     else
         if [ "$1" = "latest" ]; then
             version=""

--- a/src/scripts/macos/install.sh
+++ b/src/scripts/macos/install.sh
@@ -2,12 +2,7 @@
 Install_AWS_CLI() {
     echo "Installing AWS CLI v$version"
     if [ "$USE_BREW" -eq 1 ]; then
-        if [ "$1" = "latest" ]; then
-            version=""
-        else
-            version="@$1"
-        fi
-        brew install "awscli$version"
+        brew install "awscli"
     else
         if [ "$1" = "latest" ]; then
             version=""


### PR DESCRIPTION
I'm adding an option to install the cli with brew on MacOS, as the installation from source doesn't work when using python 3.12 as reported on this issue #205.