### PR TITLE
fix: Multiple setups not doing the right configuration

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -395,11 +395,13 @@ executors:
   macos:
     macos:
       xcode: 14.2.0
+    shell: bash -eox pipefail
   arm:
     machine:
       image: ubuntu-2004:current
     resource_class: arm.medium
   linuxvm:
+    shell: bash -eox pipefail
     machine:
       image: ubuntu-2004:current
   windows:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -154,6 +154,26 @@ jobs:
     steps:
       - aws-cli/install:
           use_brew: true
+  integration-test-multiple-setups-reverse:
+    parameters:
+      executor:
+        type: executor
+      role_arn:
+        type: string
+    executor: <<parameters.executor>>
+    steps:
+      - aws-cli/setup:
+          profile_name: integration-test-multiple-setups-env
+      - run: |
+          aws sts get-caller-identity --profile integration-test-multiple-setups-env
+      - aws-cli/setup:
+          profile_name: integration-test-multiple-setups-oidc
+          role_arn: <<parameters.role_arn>>
+      - run: |
+          cat ~/.aws/config
+          cat ~/.aws/credentials
+      - run: |
+          aws sts get-caller-identity --profile integration-test-multiple-setups-oidc
   integration-test-multiple-setups:
     parameters:
       executor:
@@ -178,6 +198,13 @@ jobs:
 workflows:
   test-deploy:
     jobs:
+      - integration-test-multiple-setups-reverse:
+          context: [CPE_ORBS_AWS]
+          role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+          matrix:
+            alias: integration-test-multiple-setups
+            parameters:
+              executor: [macos, linuxvm]
       - integration-test-multiple-setups:
           context: [CPE_ORBS_AWS]
           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -403,7 +403,7 @@ executors:
       image: ubuntu-2004:current
     resource_class: arm.medium
   linuxvm:
-    # shell: bash -eox pipefail
+    shell: bash -eox pipefail
     machine:
       image: ubuntu-2004:current
   windows:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -154,9 +154,33 @@ jobs:
     steps:
       - aws-cli/install:
           use_brew: true
+  integration-test-multiple-setups:
+    parameters:
+      executor:
+        type: executor
+      role_arn:
+        type: string
+    executor: <<parameters.executor>>
+    steps:
+      - aws-cli/setup:
+          profile_name: integration-test-multiple-setups-oidc
+          role_arn: <<parameters.role_arn>>
+      - run: |
+          aws sts get-caller-identity --profile integration-test-multiple-setups-oidc
+      - aws-cli/setup:
+          profile_name: integration-test-multiple-setups-env
+      - run: |
+          aws sts get-caller-identity --profile integration-test-multiple-setups-env
 workflows:
   test-deploy:
     jobs:
+      - integration-test-multiple-setups:
+          context: [CPE_ORBS_AWS]
+          role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
+          matrix:
+            alias: integration-test-multiple-setups
+            parameters:
+              executor: [macos, linuxvm]
       - integration-test-brew-install:
           post-steps:
             - check_aws_version
@@ -346,7 +370,7 @@ workflows:
           pub_type: production
           enable_pr_comment: true
           context: orb-publisher
-          requires: [orb-tools/pack, test-install, test-install-version, test-install-override-version, integration-test-web-identity-with-profile, integration test web identity command with white spaces,integration-test-role-arn-config, test-install-override-version-with-latest, integration-test-skip-install-matched-version, integration-test-brew-install]
+          requires: [orb-tools/pack, test-install, test-install-version, test-install-override-version, integration-test-web-identity-with-profile, integration test web identity command with white spaces,integration-test-role-arn-config, test-install-override-version-with-latest, integration-test-skip-install-matched-version, integration-test-brew-install, integration-test-multiple-setups]
           filters: *release-filters
 executors:
   terraform:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -167,6 +167,9 @@ jobs:
           role_arn: <<parameters.role_arn>>
       - run: |
           aws sts get-caller-identity --profile integration-test-multiple-setups-oidc
+      - run: |
+          cat ~/.aws/config
+          cat ~/.aws/credentials
       - aws-cli/setup:
           profile_name: integration-test-multiple-setups-env
       - run: |

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -163,6 +163,7 @@ jobs:
     executor: <<parameters.executor>>
     steps:
       - aws-cli/setup:
+          set_aws_env_vars: false
           profile_name: integration-test-multiple-setups-oidc
           role_arn: <<parameters.role_arn>>
       - run: |

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -404,7 +404,6 @@ executors:
       image: ubuntu-2004:current
     resource_class: arm.medium
   linuxvm:
-    shell: bash -eox pipefail
     machine:
       image: ubuntu-2004:current
   windows:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -167,11 +167,11 @@ jobs:
           role_arn: <<parameters.role_arn>>
       - run: |
           aws sts get-caller-identity --profile integration-test-multiple-setups-oidc
+      - aws-cli/setup:
+          profile_name: integration-test-multiple-setups-env
       - run: |
           cat ~/.aws/config
           cat ~/.aws/credentials
-      - aws-cli/setup:
-          profile_name: integration-test-multiple-setups-env
       - run: |
           aws sts get-caller-identity --profile integration-test-multiple-setups-env
 workflows:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -202,7 +202,7 @@ workflows:
           context: [CPE_ORBS_AWS]
           role_arn: arn:aws:iam::122211685980:role/CPE_ECR_OIDC_TEST
           matrix:
-            alias: integration-test-multiple-setups
+            alias: integration-test-multiple-setups-reverse
             parameters:
               executor: [macos, linuxvm]
       - integration-test-multiple-setups:
@@ -401,7 +401,7 @@ workflows:
           pub_type: production
           enable_pr_comment: true
           context: orb-publisher
-          requires: [orb-tools/pack, test-install, test-install-version, test-install-override-version, integration-test-web-identity-with-profile, integration test web identity command with white spaces,integration-test-role-arn-config, test-install-override-version-with-latest, integration-test-skip-install-matched-version, integration-test-brew-install, integration-test-multiple-setups]
+          requires: [orb-tools/pack, test-install, test-install-version, test-install-override-version, integration-test-web-identity-with-profile, integration test web identity command with white spaces,integration-test-role-arn-config, test-install-override-version-with-latest, integration-test-skip-install-matched-version, integration-test-brew-install, integration-test-multiple-setups, integration-test-multiple-setups-reverse]
           filters: *release-filters
 executors:
   terraform:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -398,13 +398,12 @@ executors:
   macos:
     macos:
       xcode: 14.2.0
-    shell: bash -eox pipefail
   arm:
     machine:
       image: ubuntu-2004:current
     resource_class: arm.medium
   linuxvm:
-    shell: bash -eox pipefail
+    # shell: bash -eox pipefail
     machine:
       image: ubuntu-2004:current
   windows:

--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -135,6 +135,7 @@ steps:
   - run:
       name: Configure AWS Access Key ID
       environment:
+        AWS_CLI_STR_ROLE_ARN: <<parameters.role_arn>>
         AWS_CLI_STR_ACCESS_KEY_ID: <<parameters.aws_access_key_id>>
         AWS_CLI_STR_SECRET_ACCESS_KEY: <<parameters.aws_secret_access_key>>
         AWS_CLI_STR_PROFILE_NAME: <<parameters.profile_name>>

--- a/src/scripts/configure.sh
+++ b/src/scripts/configure.sh
@@ -17,7 +17,7 @@ else
     touch "${BASH_ENV}"
     . "${BASH_ENV}"
 fi
-
+echo "Key after subst is: $AWS_CLI_STR_ACCESS_KEY_ID"
 aws configure set aws_access_key_id \
     "$AWS_CLI_STR_ACCESS_KEY_ID" \
     --profile "$AWS_CLI_STR_PROFILE_NAME"
@@ -26,7 +26,7 @@ aws configure set aws_secret_access_key \
     "$AWS_CLI_STR_SECRET_ACCESS_KEY" \
     --profile "$AWS_CLI_STR_PROFILE_NAME"
 
-if [ -n "${AWS_CLI_STR_SESSION_TOKEN}" ]; then
+if [ -n "${AWS_CLI_STR_ROLE_ARN}" ]; then
     aws configure set aws_session_token \
         "${AWS_CLI_STR_SESSION_TOKEN}" \
         --profile "$AWS_CLI_STR_PROFILE_NAME"

--- a/src/scripts/configure.sh
+++ b/src/scripts/configure.sh
@@ -6,6 +6,7 @@ AWS_CLI_STR_SESSION_TOKEN="$(echo "$AWS_CLI_STR_SESSION_TOKEN" | circleci env su
 AWS_CLI_STR_REGION="$(echo "$AWS_CLI_STR_REGION" | circleci env subst)"
 AWS_CLI_STR_PROFILE_NAME="$(echo "$AWS_CLI_STR_PROFILE_NAME" | circleci env subst)"
 AWS_CLI_BOOL_SET_AWS_ENV_VARS="$(echo "$AWS_CLI_BOOL_SET_AWS_ENV_VARS" | circleci env subst)"
+AWS_CLI_STR_ROLE_ARN="$(echo "${AWS_CLI_STR_ROLE_ARN}" | circleci env subst)"
 
 if [ -z "$AWS_CLI_STR_ACCESS_KEY_ID" ] && [ -z "${AWS_CLI_STR_SECRET_ACCESS_KEY}" ] && [ "$AWS_CLI_BOOL_SET_AWS_ENV_VARS" = 0 ]; then 
     temp_file="/tmp/${AWS_CLI_STR_PROFILE_NAME}.keys"
@@ -23,7 +24,7 @@ aws configure set aws_secret_access_key \
     "$AWS_CLI_STR_SECRET_ACCESS_KEY" \
     --profile "$AWS_CLI_STR_PROFILE_NAME"
 
-if [ -n "${AWS_CLI_STR_SESSION_TOKEN}" ]; then
+if [ -n "${AWS_CLI_STR_ROLE_ARN}" ]; then
     aws configure set aws_session_token \
         "${AWS_CLI_STR_SESSION_TOKEN}" \
         --profile "$AWS_CLI_STR_PROFILE_NAME"

--- a/src/scripts/configure.sh
+++ b/src/scripts/configure.sh
@@ -8,7 +8,7 @@ AWS_CLI_STR_PROFILE_NAME="$(echo "$AWS_CLI_STR_PROFILE_NAME" | circleci env subs
 AWS_CLI_BOOL_SET_AWS_ENV_VARS="$(echo "$AWS_CLI_BOOL_SET_AWS_ENV_VARS" | circleci env subst)"
 AWS_CLI_STR_ROLE_ARN="$(echo "${AWS_CLI_STR_ROLE_ARN}" | circleci env subst)"
 
-if [ -z "$AWS_CLI_STR_ACCESS_KEY_ID" ] && [ -z "${AWS_CLI_STR_SECRET_ACCESS_KEY}" ] && [ "$AWS_CLI_BOOL_SET_AWS_ENV_VARS" = 0 ]; then 
+if [ "$AWS_CLI_BOOL_SET_AWS_ENV_VARS" = 0 ]; then 
     temp_file="/tmp/${AWS_CLI_STR_PROFILE_NAME}.keys"
     . "$temp_file"
 else 
@@ -23,7 +23,7 @@ aws configure set aws_secret_access_key \
     "$AWS_CLI_STR_SECRET_ACCESS_KEY" \
     --profile "$AWS_CLI_STR_PROFILE_NAME"
 
-if [ -n "${AWS_CLI_STR_SESSION_TOKEN}" ]; then
+if [ -n "${AWS_CLI_STR_ROLE_ARN}" ]; then
     aws configure set aws_session_token \
         "${AWS_CLI_STR_SESSION_TOKEN}" \
         --profile "$AWS_CLI_STR_PROFILE_NAME"

--- a/src/scripts/configure.sh
+++ b/src/scripts/configure.sh
@@ -1,8 +1,6 @@
 #!/bin/sh
 #shellcheck disable=SC1090
-echo "Key before subst is: $AWS_CLI_STR_ACCESS_KEY_ID"
 AWS_CLI_STR_ACCESS_KEY_ID="$(echo "\$$AWS_CLI_STR_ACCESS_KEY_ID" | circleci env subst)"
-echo "Key after subst is: $AWS_CLI_STR_ACCESS_KEY_ID"
 AWS_CLI_STR_SECRET_ACCESS_KEY="$(echo "\$$AWS_CLI_STR_SECRET_ACCESS_KEY" | circleci env subst)"
 AWS_CLI_STR_SESSION_TOKEN="$(echo "$AWS_CLI_STR_SESSION_TOKEN" | circleci env subst)"
 AWS_CLI_STR_REGION="$(echo "$AWS_CLI_STR_REGION" | circleci env subst)"
@@ -17,7 +15,6 @@ else
     touch "${BASH_ENV}"
     . "${BASH_ENV}"
 fi
-echo "Key after subst is: $AWS_CLI_STR_ACCESS_KEY_ID"
 aws configure set aws_access_key_id \
     "$AWS_CLI_STR_ACCESS_KEY_ID" \
     --profile "$AWS_CLI_STR_PROFILE_NAME"

--- a/src/scripts/configure.sh
+++ b/src/scripts/configure.sh
@@ -23,7 +23,7 @@ aws configure set aws_secret_access_key \
     "$AWS_CLI_STR_SECRET_ACCESS_KEY" \
     --profile "$AWS_CLI_STR_PROFILE_NAME"
 
-if [ -n "${AWS_CLI_STR_ROLE_ARN}" ]; then
+if [ -n "${AWS_CLI_STR_SESSION_TOKEN}" ]; then
     aws configure set aws_session_token \
         "${AWS_CLI_STR_SESSION_TOKEN}" \
         --profile "$AWS_CLI_STR_PROFILE_NAME"

--- a/src/scripts/configure.sh
+++ b/src/scripts/configure.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 #shellcheck disable=SC1090
+echo "Key before subst is: $AWS_CLI_STR_ACCESS_KEY_ID"
 AWS_CLI_STR_ACCESS_KEY_ID="$(echo "\$$AWS_CLI_STR_ACCESS_KEY_ID" | circleci env subst)"
+echo "Key after subst is: $AWS_CLI_STR_ACCESS_KEY_ID"
 AWS_CLI_STR_SECRET_ACCESS_KEY="$(echo "\$$AWS_CLI_STR_SECRET_ACCESS_KEY" | circleci env subst)"
 AWS_CLI_STR_SESSION_TOKEN="$(echo "$AWS_CLI_STR_SESSION_TOKEN" | circleci env subst)"
 AWS_CLI_STR_REGION="$(echo "$AWS_CLI_STR_REGION" | circleci env subst)"
@@ -24,7 +26,7 @@ aws configure set aws_secret_access_key \
     "$AWS_CLI_STR_SECRET_ACCESS_KEY" \
     --profile "$AWS_CLI_STR_PROFILE_NAME"
 
-if [ -n "${AWS_CLI_STR_ROLE_ARN}" ]; then
+if [ -n "${AWS_CLI_STR_SESSION_TOKEN}" ]; then
     aws configure set aws_session_token \
         "${AWS_CLI_STR_SESSION_TOKEN}" \
         --profile "$AWS_CLI_STR_PROFILE_NAME"


### PR DESCRIPTION
On issue #198 and #139 there was presented an issue, where doing multiple setup, one with oidc and then one with env, caused the second one to have an authentication error. This was due to a wrong configuration on the job, but also a bug on the validations on the configure script. 
Here I'm fixing that and also adding new tests to validate this behavior.