### PR TITLE
Resolves issues with static credentials auth and add tests

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -195,6 +195,17 @@ jobs:
           cat ~/.aws/credentials
       - run: |
           aws sts get-caller-identity --profile integration-test-multiple-setups-env
+  integration-test-static-credentials:
+    parameters:
+      executor:
+        type: executor
+    executor: <<parameters.executor>>
+    steps:
+      - aws-cli/setup:
+          aws_access_key_id: $AWS_ACCESS_KEY_ID
+          aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
+      - run: |
+          aws sts get-caller-identity
 workflows:
   test-deploy:
     jobs:
@@ -360,6 +371,12 @@ workflows:
           post-steps:
             - check_aws_version:
                 version: "2.15.57"
+      - integration-test-static-credentials:
+          context: [CPE_ORBS_AWS]
+          matrix:
+            alias: integration-test-static-credentials
+            parameters:
+              executor: ["linuxvm", "windows", "arm"]
       - integration-test-install:
           name: integration-test-skip-install-matched-version
           context: [CPE_ORBS_AWS]
@@ -401,7 +418,7 @@ workflows:
           pub_type: production
           enable_pr_comment: true
           context: orb-publisher
-          requires: [orb-tools/pack, test-install, test-install-version, test-install-override-version, integration-test-web-identity-with-profile, integration test web identity command with white spaces,integration-test-role-arn-config, test-install-override-version-with-latest, integration-test-skip-install-matched-version, integration-test-brew-install, integration-test-multiple-setups, integration-test-multiple-setups-reverse]
+          requires: [orb-tools/pack, integration-test-static-credentials, test-install, test-install-version, test-install-override-version, integration-test-web-identity-with-profile, integration test web identity command with white spaces,integration-test-role-arn-config, test-install-override-version-with-latest, integration-test-skip-install-matched-version, integration-test-brew-install, integration-test-multiple-setups, integration-test-multiple-setups-reverse]
           filters: *release-filters
 executors:
   terraform:

--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -45,7 +45,7 @@ parameters:
       the environment variable you will use to hold this
       value, i.e. AWS_ACCESS_KEY.
     type: string
-    default: AWS_ACCESS_KEY_ID
+    default: $AWS_ACCESS_KEY_ID
 
   aws_secret_access_key:
     description: |
@@ -53,7 +53,7 @@ parameters:
       the environment variable you will use to hold this
       value, i.e. AWS_SECRET_ACCESS_KEY.
     type: string
-    default: AWS_SECRET_ACCESS_KEY
+    default: $AWS_SECRET_ACCESS_KEY
 
   region:
     description: |

--- a/src/scripts/configure.sh
+++ b/src/scripts/configure.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 #shellcheck disable=SC1090
-AWS_CLI_STR_ACCESS_KEY_ID="$(echo "\$$AWS_CLI_STR_ACCESS_KEY_ID" | circleci env subst)"
-AWS_CLI_STR_SECRET_ACCESS_KEY="$(echo "\$$AWS_CLI_STR_SECRET_ACCESS_KEY" | circleci env subst)"
+AWS_CLI_STR_ACCESS_KEY_ID="$(echo "$AWS_CLI_STR_ACCESS_KEY_ID" | circleci env subst)"
+AWS_CLI_STR_SECRET_ACCESS_KEY="$(echo "$AWS_CLI_STR_SECRET_ACCESS_KEY" | circleci env subst)"
 AWS_CLI_STR_SESSION_TOKEN="$(echo "$AWS_CLI_STR_SESSION_TOKEN" | circleci env subst)"
 AWS_CLI_STR_REGION="$(echo "$AWS_CLI_STR_REGION" | circleci env subst)"
 AWS_CLI_STR_PROFILE_NAME="$(echo "$AWS_CLI_STR_PROFILE_NAME" | circleci env subst)"


### PR DESCRIPTION
The configure script was still managing the static credentials as if they were environment_variable type, and they are string now.
I'm updating the defaults and the script to work as they are supposed to, and adding a new test that validate the setup when using static credentials authentication.