### PR TITLE
add disable_aws_install flag to setup

### DIFF
--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -115,8 +115,7 @@ parameters:
 steps:
   - when:
       condition:
-        not:
-          - <<parameters.disable_aws_install>>
+        not: <<parameters.disable_aws_install>>
       steps:
         - install:
             version: <<parameters.version>>

--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -106,14 +106,25 @@ parameters:
       Set to true if you want to use brew to install the awscli. Only compatible with MacOs executor. Default to false.
       When using brew, only the brew version is available.
 
+  disable_aws_install:
+    type: boolean
+    default: false
+    description: |
+      Set to true if you want to disable the AWS CLI install step. Default to false.
+
 steps:
-  - install:
-      version: <<parameters.version>>
-      disable_aws_pager: <<parameters.disable_aws_pager>>
-      override_installed: <<parameters.override_installed>>
-      install_dir: <<parameters.install_dir>>
-      binary_dir: <<parameters.binary_dir>>
-      use_brew: <<parameters.use_brew>>
+  - when:
+      condition:
+        not:
+          - <<parameters.disable_aws_install>>
+      steps:
+        - install:
+            version: <<parameters.version>>
+            disable_aws_pager: <<parameters.disable_aws_pager>>
+            override_installed: <<parameters.override_installed>>
+            install_dir: <<parameters.install_dir>>
+            binary_dir: <<parameters.binary_dir>>
+            use_brew: <<parameters.use_brew>>
   - when:
       condition:
         and:


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

I'd like to use this orb to setup AWS access and secret tokens using an OIDC role without running through the AWS CLI install steps.

### Description

Adds a flag to the `aws-cli/setup` job to skip the AWS CLI install step.
