### PR TITLE
Update script to not exit 0 when the OIDC token is set

### DIFF
--- a/src/scripts/assume_role_with_web_identity.sh
+++ b/src/scripts/assume_role_with_web_identity.sh
@@ -15,20 +15,25 @@ if [ -z "${AWS_CLI_STR_ROLE_SESSION_NAME}" ]; then
 fi
 
 if [ -z "${CIRCLE_OIDC_TOKEN_V2}" ] || [ -z "${CIRCLE_OIDC_TOKEN}" ]; then
+    TOKEN_SETUP_SUCCESS=false
     for i in {1..3}; do
-        echo "Attempt $i: Checking OIDC tokens"
+        echo "Attempt $i: Minting OIDC tokens"
         CIRCLE_OIDC_TOKEN=$(circleci run oidc get --claims "{\"aud\":\"${CIRCLE_ORGANIZATION_ID}\"}")
-        if [ -n "$CIRCLE_OIDC_TOKEN" ] || [ -n "$CIRCLE_OIDC_TOKEN_V2" ]; then
+        if [ -n "$CIRCLE_OIDC_TOKEN" ]; then
             echo "Successfully set CIRCLE_OIDC_TOKEN"
             echo 'export CIRCLE_OIDC_TOKEN="'"$CIRCLE_OIDC_TOKEN"'"' >> "$BASH_ENV"
             echo 'export CIRCLE_OIDC_TOKEN_V2="'"$CIRCLE_OIDC_TOKEN"'"' >> "$BASH_ENV"
-            exit 0
+            TOKEN_SETUP_SUCCESS=true
+            break
         fi
         echo "Waiting 1 second before retry"
         sleep 1
     done
-    echo "Failed to set CIRCLE_OIDC_TOKEN_V2 after 3 attempts"
-    exit 1
+    
+    if [ "$TOKEN_SETUP_SUCCESS" = false ]; then
+        echo "Failed to set CIRCLE_OIDC_TOKEN and CIRCLE_OIDC_TOKEN_V2 after 3 attempts. Please try rerunning the worklow."
+        exit 1
+    fi
 fi
 
 if [ ! "$(command -v aws)" ]; then


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

#221 had a small bug where it would exit 0 and end the script if the new tokens were minted. This would require you to run `aws-cli/setup` twice. 
This fixes that bug by only exiting if the tokens do not mint.

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
