### PR TITLE
Update web identity role assumption to support parameters that reference environment variables set with $BASH_ENV

### DIFF
--- a/src/scripts/assume_role_with_web_identity.sh
+++ b/src/scripts/assume_role_with_web_identity.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
+
+# Ensure that we load any variables specified by earlier steps
+source "$BASH_ENV"
+
 AWS_CLI_STR_ROLE_SESSION_NAME="$(echo "${AWS_CLI_STR_ROLE_SESSION_NAME}" | circleci env subst)"
 AWS_CLI_STR_ROLE_ARN="$(echo "${AWS_CLI_STR_ROLE_ARN}" | circleci env subst)"
 AWS_CLI_STR_PROFILE_NAME="$(echo "${AWS_CLI_STR_PROFILE_NAME}" | circleci env subst)"

--- a/src/scripts/assume_role_with_web_identity.sh
+++ b/src/scripts/assume_role_with_web_identity.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+#shellcheck disable=SC1090
 
 # Ensure variables are loaded from $BASH_ENV as required
 touch "${BASH_ENV}"

--- a/src/scripts/assume_role_with_web_identity.sh
+++ b/src/scripts/assume_role_with_web_identity.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
-# Ensure that we load any variables specified by earlier steps
-source "$BASH_ENV"
+# Ensure variables are loaded from $BASH_ENV as required
+touch "${BASH_ENV}"
+. "${BASH_ENV}"
 
 AWS_CLI_STR_ROLE_SESSION_NAME="$(echo "${AWS_CLI_STR_ROLE_SESSION_NAME}" | circleci env subst)"
 AWS_CLI_STR_ROLE_ARN="$(echo "${AWS_CLI_STR_ROLE_ARN}" | circleci env subst)"

--- a/src/scripts/configure.sh
+++ b/src/scripts/configure.sh
@@ -1,5 +1,15 @@
 #!/bin/sh
 #shellcheck disable=SC1090
+
+# Ensure variables are loaded from $BASH_ENV as required
+touch "${BASH_ENV}"
+. "${BASH_ENV}"
+
+if [ "$AWS_CLI_BOOL_SET_AWS_ENV_VARS" = 0 ]; then 
+    temp_file="/tmp/${AWS_CLI_STR_PROFILE_NAME}.keys"
+    . "$temp_file" 
+fi
+
 AWS_CLI_STR_ACCESS_KEY_ID="$(echo "$AWS_CLI_STR_ACCESS_KEY_ID" | circleci env subst)"
 AWS_CLI_STR_SECRET_ACCESS_KEY="$(echo "$AWS_CLI_STR_SECRET_ACCESS_KEY" | circleci env subst)"
 AWS_CLI_STR_SESSION_TOKEN="$(echo "$AWS_CLI_STR_SESSION_TOKEN" | circleci env subst)"
@@ -8,13 +18,6 @@ AWS_CLI_STR_PROFILE_NAME="$(echo "$AWS_CLI_STR_PROFILE_NAME" | circleci env subs
 AWS_CLI_BOOL_SET_AWS_ENV_VARS="$(echo "$AWS_CLI_BOOL_SET_AWS_ENV_VARS" | circleci env subst)"
 AWS_CLI_STR_ROLE_ARN="$(echo "${AWS_CLI_STR_ROLE_ARN}" | circleci env subst)"
 
-if [ "$AWS_CLI_BOOL_SET_AWS_ENV_VARS" = 0 ]; then 
-    temp_file="/tmp/${AWS_CLI_STR_PROFILE_NAME}.keys"
-    . "$temp_file"
-else 
-    touch "${BASH_ENV}"
-    . "${BASH_ENV}"
-fi
 aws configure set aws_access_key_id \
     "$AWS_CLI_STR_ACCESS_KEY_ID" \
     --profile "$AWS_CLI_STR_PROFILE_NAME"


### PR DESCRIPTION
### Checklist

- [X] All new jobs, commands, executors, parameters have descriptions
- [X] Examples have been added for any significant new features
- [X] README has been updated, if necessary

### Motivation, issues

[CircleCI supports passing environment variables between steps](https://circleci.com/docs/set-environment-variable/#set-an-environment-variable-in-a-shell-command) using the file specified in "$BASH_ENV". The `assume_role_with_web_identity` script forces the use of `sh` as the shell, and therefore doesn't have access to environment variables specified in previous steps, as it is not loaded automatically into the shell environment. 

As such, if a user leverages the orb in the following way, but specified values for the environment variables in $BASH_ENV, `assume_role_with_web_identity` will fail:
```yaml
      - aws-cli/setup:
          role_arn: $OIDC_IAM_ROLE_ARN
          region: $OIDC_AWS_REGION
```

### Description
- Updates `assume_role_with_web_identity.sh` to source $BASH_ENV to load any environment variables written to this file in previous job steps. This aligns the Orb with guidance from CircleCI on sharing environment variables between steps in a job
