### PR TITLE
Allow CLI commands to be always executed

### DIFF
--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -34,9 +34,19 @@ parameters:
     description: |
       Set to true if you want to use the Homebrew CLI to install the awscli. Only compatible with the macOS executor. Defaults to false.
       When using brew, only the brew version is available.
+  when:
+    description: |
+      Allows script to run on a specific condition of a workflow.
+      The default is 'on_success', means the script will run only if all previous steps were successful
+      'on_fail' means the script will run if any previous step fails
+      'always' means it will run regardless of the success or failure of previous steps in the workflow
+    type: enum
+    enum: ["on_success", "on_fail", "always"]
+    default: "on_success"
 steps:
   - run:
       name: Install AWS CLI - <<parameters.version>>
+      when: <<parameters.when>>
       environment:
         AWS_CLI_STR_AWS_CLI_VERSION: <<parameters.version>>
         AWS_CLI_BOOL_DISABLE_PAGER: <<parameters.disable_aws_pager>>

--- a/src/commands/role_arn_setup.yml
+++ b/src/commands/role_arn_setup.yml
@@ -14,9 +14,20 @@ parameters:
     type: string
     default: "default"
 
+  when:
+    description: |
+      Allows script to run on a specific condition of a workflow.
+      The default is 'on_success', means the script will run only if all previous steps were successful
+      'on_fail' means the script will run if any previous step fails
+      'always' means it will run regardless of the success or failure of previous steps in the workflow
+    type: enum
+    enum: ["on_success", "on_fail", "always"]
+    default: "on_success"
+
 steps:
   - run:
       name: Configure role arn for profile <<parameters.profile_name>>
+      when: <<parameters.when>>
       environment:
         AWS_CLI_STR_PROFILE_NAME: <<parameters.profile_name>>
         AWS_CLI_STR_SOURCE_PROFILE: <<parameters.source_profile>>

--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -111,6 +111,16 @@ parameters:
     default: false
     description: |
       Set to true if you want to disable the AWS CLI install step. Default to false.
+  
+  when:
+    description: |
+      Allows script to run on a specific condition of a workflow.
+      The default is 'on_success', means the script will run only if all previous steps were successful
+      'on_fail' means the script will run if any previous step fails
+      'always' means it will run regardless of the success or failure of previous steps in the workflow
+    type: enum
+    enum: ["on_success", "on_fail", "always"]
+    default: "on_success"
 
 steps:
   - when:
@@ -118,6 +128,7 @@ steps:
         not: <<parameters.disable_aws_install>>
       steps:
         - install:
+            when: <<parameters.when>>
             version: <<parameters.version>>
             disable_aws_pager: <<parameters.disable_aws_pager>>
             override_installed: <<parameters.override_installed>>
@@ -132,6 +143,7 @@ steps:
       steps:
         - run:
             name: Assume Role with Web Identity
+            when: <<parameters.when>>
             environment:
               AWS_CLI_STR_ROLE_ARN: <<parameters.role_arn>>
               AWS_CLI_STR_ROLE_SESSION_NAME: <<parameters.role_session_name>>
@@ -142,6 +154,7 @@ steps:
             command: <<include(scripts/assume_role_with_web_identity.sh)>>
   - run:
       name: Configure AWS Access Key ID
+      when: <<parameters.when>>
       environment:
         AWS_CLI_STR_ROLE_ARN: <<parameters.role_arn>>
         AWS_CLI_STR_ACCESS_KEY_ID: <<parameters.aws_access_key_id>>

--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -111,7 +111,7 @@ parameters:
     default: false
     description: |
       Set to true if you want to disable the AWS CLI install step. Default to false.
-  
+
   when:
     description: |
       Allows script to run on a specific condition of a workflow.


### PR DESCRIPTION
1. Propagate 'when' parameter to the script execution steps which allows to run aws cli scripts conditionally depending on a workflow status 'on_success', means the script will run only if all previous steps were successful 'on_fail' means the script will run if any previous step fails 'always' means it will run regardless of the success or failure of previous steps in the workflow
2. Default value set to 'on_success' in order to preserve current behavior

### Motivation, issues

In some cases aws-cli setup should be executed even when the previous step of the workflow failed.  
As an example, we upload test results to an s3 no matter if tests passed or failed.  
Right now aws-setup can't be called for any previous step of the workflow failed.
This changes allow to propagate 'when' parameter (behavior borrowed from the CircleCI [run](https://circleci.com/docs/configuration-reference/#run) step) so we can tell the aws-cli script to run even when workflow marked as failed