### PR TITLE
Support setting AWS_ROLE_ARN via env var for aws-cli/setup

### DIFF
--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -1,7 +1,8 @@
 description: |
   Installs aws-cli and then configure and store AWS credentials in
   ~/.aws/credentials and ~/.aws/config.
-  If role_session_name and role_arn are provided, it will attempt to use OIDC auth.
+  If role_arn is set, either explicitly or by the value of $AWS_ROLE_ARN, this command will attempt to use OIDC
+  auth.
 
 parameters:
   version:
@@ -77,7 +78,8 @@ parameters:
   role_arn:
     description: |
       The Amazon Resource Name (ARN) of the role that the caller is assuming.
-      Role ARN must be configured for web identity.
+      Role ARN must be configured for web identity / OIDC auth.
+      (defaults to env var of ${AWS_ROLE_ARN})
     type: string
     default: ${AWS_ROLE_ARN}
 

--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -149,6 +149,8 @@ steps:
         and:
           - <<parameters.role_session_name>>
           - <<parameters.role_arn>>
+          - not:
+            - equal: [<<parameters.role_arn>>, ""]
           - not: <<parameters.disable_oidc>>
       steps:
         - run:

--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -79,7 +79,7 @@ parameters:
       The Amazon Resource Name (ARN) of the role that the caller is assuming.
       Role ARN must be configured for web identity.
     type: string
-    default: ""
+    default: ${AWS_ROLE_ARN}
 
   role_session_name:
     description: An identifier for the assumed role session

--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -148,9 +148,6 @@ steps:
       condition:
         and:
           - <<parameters.role_session_name>>
-          - <<parameters.role_arn>>
-          - not:
-            - equal: [<<parameters.role_arn>>, ""]
           - not: <<parameters.disable_oidc>>
       steps:
         - run:

--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -2,7 +2,7 @@ description: |
   Installs aws-cli and then configure and store AWS credentials in
   ~/.aws/credentials and ~/.aws/config.
   If role_arn is set, either explicitly or by the value of $AWS_ROLE_ARN, this command will attempt to use OIDC
-  auth.
+  auth. If you're providing $AWS_ROLE_ARN but don't want to use OIDC auth, set disable_oidc to true.
 
 parameters:
   version:
@@ -114,6 +114,13 @@ parameters:
     description: |
       Set to true if you want to disable the AWS CLI install step. Default to false.
 
+  disable_oidc:
+    type: boolean
+    default: false
+    description: |
+      Set to true if you want don't want to use OIDC auth but are setting $AWS_ROLE_ARN. This command will otherwise
+      attempt to use OIDC auth if $AWS_ROLE_ARN is set.
+
   when:
     description: |
       Allows script to run on a specific condition of a workflow.
@@ -142,6 +149,7 @@ steps:
         and:
           - <<parameters.role_session_name>>
           - <<parameters.role_arn>>
+          - not: <<parameters.disable_oidc>>
       steps:
         - run:
             name: Assume Role with Web Identity

--- a/src/scripts/assume_role_with_web_identity.sh
+++ b/src/scripts/assume_role_with_web_identity.sh
@@ -15,6 +15,11 @@ AWS_CLI_BOOL_SET_AWS_ENV_VARS="$(echo "${AWS_CLI_BOOL_SET_AWS_ENV_VARS}" | circl
 AWS_CLI_STR_ROLE_SESSION_NAME=$(printf '%s' "${AWS_CLI_STR_ROLE_SESSION_NAME}" | tr -sC 'A-Za-z0-9=,.@_\-' '-')
 AWS_CLI_STR_ROLE_SESSION_NAME=$(echo "${AWS_CLI_STR_ROLE_SESSION_NAME}" | cut -c -64)
 
+if [ -z "${AWS_CLI_STR_ROLE_ARN}" ]; then
+    echo "Role ARN is not specified. Skipping assume role with web identity."
+    exit 0
+fi
+
 if [ -z "${AWS_CLI_STR_ROLE_SESSION_NAME}" ]; then
     echo "Role session name is required"
     exit 1


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

Reduce boilerplate config when using OIDC roles. We set AWS_ROLE_ARN but currently have to set the following where OIDC roles are used:

```yaml
steps:
 - aws-cli/setup:
      role_arn: "${AWS_ROLE_ARN}"
```

With this change, it would be possible to use `aws-cli/setup` directly as below, assuming $AWS_ROLE_ARN is set.

```yaml
steps:
  - aws-cli/setup
```

At a glance, it looks like this orb tries to support many of the same aws-cli ENV vars where it makes sense. In this case, [AWS_ROLE_ARN](https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-envvars.html#envvars-list-AWS_ROLE_ARN) is also an AWS CLI env var, so that aspect matches existing behavior.

That said, the AWS_ROLE_ARN param is usually used in conjunction with AWS_WEB_IDENTITY_TOKEN_FILE env var to implicitly use web identity creds, whereas the orb explicitly assumes the web identity and pulls the resulting access key/creds from it. So the behavior diverges a bit there.

Supporting AWS_ROLE_ARN would be a nice touch for usability/DRYing config, though.

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

For the `aws-cli/setup` command, default the role_arn param to $AWS_ROLE_ARN.