### PR TITLE
Fix brew install hanging on confirmation prompt in CI

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -442,7 +442,7 @@ executors:
       - image: cimg/base:stable
   macos:
     macos:
-      xcode: 15.2.0
+      xcode: 16.4.0
   arm:
     machine:
       image: ubuntu-2004:current

--- a/src/scripts/macos/install.sh
+++ b/src/scripts/macos/install.sh
@@ -2,7 +2,7 @@
 Install_AWS_CLI() {
     echo "Installing AWS CLI v$version"
     if [ "$USE_BREW" -eq 1 ]; then
-        brew install "awscli"
+        HOMEBREW_NO_ASK=1 brew install "awscli"
     else
         if [ "$1" = "latest" ]; then
             version=""

--- a/src/scripts/macos/install.sh
+++ b/src/scripts/macos/install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 Install_AWS_CLI() {
-    echo "Installing AWS CLI v$version"
+    echo "Installing AWS CLI v$1"
     if [ "$USE_BREW" -eq 1 ]; then
         HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_ASK=1 brew install "awscli"
     else

--- a/src/scripts/macos/install.sh
+++ b/src/scripts/macos/install.sh
@@ -2,7 +2,7 @@
 Install_AWS_CLI() {
     echo "Installing AWS CLI v$version"
     if [ "$USE_BREW" -eq 1 ]; then
-        HOMEBREW_NO_ASK=1 brew install "awscli"
+        HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_ASK=1 brew install "awscli"
     else
         if [ "$1" = "latest" ]; then
             version=""

--- a/src/scripts/macos/install.sh
+++ b/src/scripts/macos/install.sh
@@ -5,19 +5,13 @@ Install_AWS_CLI() {
         HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_ASK=1 brew install "awscli"
     else
         if [ "$1" = "latest" ]; then
-            version=""
+            pkg_url="https://awscli.amazonaws.com/AWSCLIV2.pkg"
         else
-            version="-$1"
+            pkg_url="https://awscli.amazonaws.com/AWSCLIV2-$1.pkg"
         fi
-        cd /tmp || exit
-        curl -o awscli.tar.gz "https://awscli.amazonaws.com/awscli$version.tar.gz"
-        mkdir awscli
-        tar -xzf awscli.tar.gz -C awscli --strip-components=1
-        rm awscli.tar.gz
-        cd awscli || exit
-        ./configure --with-download-deps
-        make
-        $SUDO make install
+        curl -o /tmp/AWSCLIV2.pkg "$pkg_url"
+        $SUDO installer -pkg /tmp/AWSCLIV2.pkg -target /
+        rm /tmp/AWSCLIV2.pkg
     fi
 }
 

--- a/src/scripts/macos/install.sh
+++ b/src/scripts/macos/install.sh
@@ -4,6 +4,9 @@ Install_AWS_CLI() {
     if [ "$USE_BREW" -eq 1 ]; then
         HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_ASK=1 brew install "awscli"
     else
+        if [ "$(uname -m)" = "arm64" ]; then
+            $SUDO softwareupdate --install-rosetta --agree-to-license || true
+        fi
         if [ "$1" = "latest" ]; then
             pkg_url="https://awscli.amazonaws.com/AWSCLIV2.pkg"
         else


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

Homebrew 6.0.0 introduced an interactive confirmation prompt when installing packages with dependencies. In CI environments, this prompt causes the `install AWS CLI - Latest` step to hang until timeout when `use_brew: true` is set on macOS.

### Description

Set `HOMEBREW_NO_ASK=1` before the `brew install` call to suppress the confirmation prompt and allow non-interactive installation in CI.